### PR TITLE
need to update dotfile repo with upstream

### DIFF
--- a/LINUX.md
+++ b/LINUX.md
@@ -228,7 +228,13 @@ Now copy/paste this very long line in your terminal. Do **not** change this one.
 mkdir -p ~/code/$GITHUB_USERNAME && cd $_ && git clone git@github.com:$GITHUB_USERNAME/dotfiles.git
 ```
 
-Run the `dotfiles` installer.
+Run this command to make sure your dotfile repo is up-to-date with that of lewagon (Call a TA if the above command fails)
+```bash
+cd ~/code/$GITHUB_USERNAME/dotfiles
+git pull upstream master -X ours
+```
+
+Then, run the `dotfiles` installer.
 
 ```bash
 cd ~/code/$GITHUB_USERNAME/dotfiles

--- a/macOS.md
+++ b/macOS.md
@@ -346,7 +346,15 @@ Now copy/paste this very long line in your terminal. Do **not** change this one.
 mkdir -p ~/code/$GITHUB_USERNAME && cd $_ && git clone git@github.com:$GITHUB_USERNAME/dotfiles.git
 ```
 
-Run the `dotfiles` installer.
+Run this command to make sure your dotfile repo is up-to-date with that of lewagon (Call a TA if the above command fails)
+```bash
+cd ~/code/$GITHUB_USERNAME/dotfiles
+git pull upstream master -X ours
+```
+
+
+
+Then, run the `dotfiles` installer.
 
 ```bash
 cd ~/code/$GITHUB_USERNAME/dotfiles

--- a/macOS.md
+++ b/macOS.md
@@ -352,8 +352,6 @@ cd ~/code/$GITHUB_USERNAME/dotfiles
 git pull upstream master -X ours
 ```
 
-
-
 Then, run the `dotfiles` installer.
 
 ```bash


### PR DESCRIPTION
While doing this data-setup day with my fresh new computer, I had an issue in section 2bis because my cloned "brunolajoie/dotfile" repo was not up to date with "lewagon/dotfile". In particular, i didn't have the "pyenv activate lewagon" in my zshrc dotfile.

So, I suggest to add the following command `git pull upstream -X ours` after the cloning and before the `zsh install.sh`.

Plz review to let me know if you think that's a good practice !
