### PR TITLE
add xz & readline to setup

### DIFF
--- a/_partials/homebrew.md
+++ b/_partials/homebrew.md
@@ -80,9 +80,12 @@ If you have something _above_ `2.24` you are good to go!
 
 `hub` is a command line tool that wraps `git` in order to extend it with extra features and commands that make working with GitHub easier.
 
+`xz` for data compression with high compression ratio
+
+`readline` is a library for command-line editing
 
 ```bash
-brew install tree ncdu htop tig hub
+brew install tree ncdu htop tig hub xz readline
 ```
 
 We are going to install more software thanks to `brew`, if you want to know what you _already_ have installed you can run:

--- a/macOS.md
+++ b/macOS.md
@@ -184,9 +184,12 @@ If you have something _above_ `2.24` you are good to go!
 
 `hub` is a command line tool that wraps `git` in order to extend it with extra features and commands that make working with GitHub easier.
 
+`xz` for data compression with high compression ratio
+
+`readline` is a library for command-line editing
 
 ```bash
-brew install tree ncdu htop tig hub
+brew install tree ncdu htop tig hub xz readline
 ```
 
 We are going to install more software thanks to `brew`, if you want to know what you _already_ have installed you can run:


### PR DESCRIPTION
add `xz` & `readline` to the setup.
They are necessary to avoid the `could not import the lzma module` error forcing the reinstall of python.