### PR TITLE
Local virtualenv

### DIFF
--- a/LINUX.md
+++ b/LINUX.md
@@ -340,7 +340,7 @@ sudo apt install -y make build-essential libssl-dev zlib1g-dev libbz2-dev \
 Let's install the [latest stable version of Python](https://www.python.org/doc/versions/) supported by Le Wagon's curriculum:
 
 ```bash
-pyenv install 3.8.5
+pyenv install 3.8.6
 ```
 
 This command might take a while, this is perfectly normal. Don't hesitate to help other students seated next to you!
@@ -348,12 +348,12 @@ This command might take a while, this is perfectly normal. Don't hesitate to hel
 OK once this command is complete, we are going to tell the system to use this version of Python **by default**. This is done with:
 
 ```bash
-pyenv global 3.8.5
+pyenv global 3.8.6
 ```
 
 Once again, quit **all your opened terminal windows** (Cmd + Q) and restart one.
 
-To check if this worked, run `python --version`. If you see `3.8.5`, perfect! If not, ask a TA that will help you debug the problem thanks to `pyenv versions` and `type -a python` (`python` should be using the `.pyenv/shims` version first).
+To check if this worked, run `python --version`. If you see `3.8.6`, perfect! If not, ask a TA that will help you debug the problem thanks to `pyenv versions` and `type -a python` (`python` should be using the `.pyenv/shims` version first).
 
 ---
 
@@ -377,34 +377,16 @@ Once again, quit **all your opened terminal windows** (Cmd + Q) and restart one.
 Let's create the virtual environment we are going to use during the whole bootcamp:
 
 ```bash
-pyenv virtualenv 3.8.5 lewagon
+pyenv virtualenv 3.8.6 lewagon
 ```
 
-Let's now activate the virtual environment with:
+Let's now set the virtual environment with:
 
 ```bash
-pyenv activate lewagon
+pyenv global lewagon
 ```
 
-Great! Anytime we'll install Python package, we'll do it in that environment. In order for you to not have to always activate it everytime you open a new terminal, we conviniently added a line to the `~/.zshrc` file:
-
-```bash
-cat ~/.zshrc | grep activate
-```
-
-As the `~/.zshrc` is executed everytime you open a new terminal, it will automatically activate the `lewagon` virtualenv. Try it now, quit **all your opened terminal windows** (Cmd + Q) and restart one. Then run:
-
-```bash
-pyenv activate lewagon
-```
-
-It should tell you:
-
-```bash
-pyenv-virtualenv: version `lewagon' is already activated
-```
-
-All good!
+Great! Anytime we'll install Python package, we'll do it in that environment.
 
 
 ## Python packages

--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -1004,7 +1004,7 @@ sudo apt install -y make build-essential libssl-dev zlib1g-dev libbz2-dev \
 Let's install the [latest stable version of Python](https://www.python.org/doc/versions/) supported by Le Wagon's curriculum:
 
 ```bash
-pyenv install 3.8.5
+pyenv install 3.8.6
 ```
 
 This command might take a while, this is perfectly normal. Don't hesitate to help other students seated next to you!
@@ -1012,12 +1012,12 @@ This command might take a while, this is perfectly normal. Don't hesitate to hel
 OK once this command is complete, we are going to tell the system to use this version of Python **by default**. This is done with:
 
 ```bash
-pyenv global 3.8.5
+pyenv global 3.8.6
 ```
 
 Once again, quit **all your opened terminal windows** (Cmd + Q) and restart one.
 
-To check if this worked, run `python --version`. If you see `3.8.5`, perfect! If not, ask a TA that will help you debug the problem thanks to `pyenv versions` and `type -a python` (`python` should be using the `.pyenv/shims` version first).
+To check if this worked, run `python --version`. If you see `3.8.6`, perfect! If not, ask a TA that will help you debug the problem thanks to `pyenv versions` and `type -a python` (`python` should be using the `.pyenv/shims` version first).
 
 ---
 
@@ -1041,34 +1041,16 @@ Once again, quit **all your opened terminal windows** (Cmd + Q) and restart one.
 Let's create the virtual environment we are going to use during the whole bootcamp:
 
 ```bash
-pyenv virtualenv 3.8.5 lewagon
+pyenv virtualenv 3.8.6 lewagon
 ```
 
-Let's now activate the virtual environment with:
+Let's now set the virtual environment with:
 
 ```bash
-pyenv activate lewagon
+pyenv global lewagon
 ```
 
-Great! Anytime we'll install Python package, we'll do it in that environment. In order for you to not have to always activate it everytime you open a new terminal, we conviniently added a line to the `~/.zshrc` file:
-
-```bash
-cat ~/.zshrc | grep activate
-```
-
-As the `~/.zshrc` is executed everytime you open a new terminal, it will automatically activate the `lewagon` virtualenv. Try it now, quit **all your opened terminal windows** (Cmd + Q) and restart one. Then run:
-
-```bash
-pyenv activate lewagon
-```
-
-It should tell you:
-
-```bash
-pyenv-virtualenv: version `lewagon' is already activated
-```
-
-All good!
+Great! Anytime we'll install Python package, we'll do it in that environment.
 
 
 ## Python packages

--- a/_partials/osx_virtualenv.md
+++ b/_partials/osx_virtualenv.md
@@ -16,28 +16,10 @@ Let's create the virtual environment we are going to use during the whole bootca
 pyenv virtualenv <PYTHON_VERSION> lewagon
 ```
 
-Let's now activate the virtual environment with:
+Let's now set the virtual environment with:
 
 ```bash
-pyenv activate lewagon
+pyenv global lewagon
 ```
 
-Great! Anytime we'll install Python package, we'll do it in that environment. In order for you to not have to always activate it everytime you open a new terminal, we conviniently added a line to the `~/.zshrc` file:
-
-```bash
-cat ~/.zshrc | grep activate
-```
-
-As the `~/.zshrc` is executed everytime you open a new terminal, it will automatically activate the `lewagon` virtualenv. Try it now, quit **all your opened terminal windows** (Cmd + Q) and restart one. Then run:
-
-```bash
-pyenv activate lewagon
-```
-
-It should tell you:
-
-```bash
-pyenv-virtualenv: version `lewagon' is already activated
-```
-
-All good!
+Great! Anytime we'll install Python package, we'll do it in that environment.

--- a/build.rb
+++ b/build.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby -wU
 
-PYTHON_VERSION = "3.8.5"
+PYTHON_VERSION = "3.8.6"
 
 # NOTE(ssaunier): This script needs https://github.com/lewagon/setup to be cloned as well
 MAC_OS = %w[

--- a/macOS.md
+++ b/macOS.md
@@ -529,7 +529,7 @@ Then quit **all your opened terminal windows** (Cmd + Q) and restart one.
 Let's install the [latest stable version of Python](https://www.python.org/doc/versions/) supported by Le Wagon's curriculum:
 
 ```bash
-pyenv install 3.8.5
+pyenv install 3.8.6
 ```
 
 This command might take a while, this is perfectly normal. Don't hesitate to help other students seated next to you!
@@ -537,12 +537,12 @@ This command might take a while, this is perfectly normal. Don't hesitate to hel
 OK once this command is complete, we are going to tell the system to use this version of Python **by default**. This is done with:
 
 ```bash
-pyenv global 3.8.5
+pyenv global 3.8.6
 ```
 
 Once again, quit **all your opened terminal windows** (Cmd + Q) and restart one.
 
-To check if this worked, run `python --version`. If you see `3.8.5`, perfect! If not, ask a TA that will help you debug the problem thanks to `pyenv versions` and `type -a python` (`python` should be using the `.pyenv/shims` version first).
+To check if this worked, run `python --version`. If you see `3.8.6`, perfect! If not, ask a TA that will help you debug the problem thanks to `pyenv versions` and `type -a python` (`python` should be using the `.pyenv/shims` version first).
 
 ---
 
@@ -566,34 +566,16 @@ Once again, quit **all your opened terminal windows** (Cmd + Q) and restart one.
 Let's create the virtual environment we are going to use during the whole bootcamp:
 
 ```bash
-pyenv virtualenv 3.8.5 lewagon
+pyenv virtualenv 3.8.6 lewagon
 ```
 
-Let's now activate the virtual environment with:
+Let's now set the virtual environment with:
 
 ```bash
-pyenv activate lewagon
+pyenv global lewagon
 ```
 
-Great! Anytime we'll install Python package, we'll do it in that environment. In order for you to not have to always activate it everytime you open a new terminal, we conviniently added a line to the `~/.zshrc` file:
-
-```bash
-cat ~/.zshrc | grep activate
-```
-
-As the `~/.zshrc` is executed everytime you open a new terminal, it will automatically activate the `lewagon` virtualenv. Try it now, quit **all your opened terminal windows** (Cmd + Q) and restart one. Then run:
-
-```bash
-pyenv activate lewagon
-```
-
-It should tell you:
-
-```bash
-pyenv-virtualenv: version `lewagon' is already activated
-```
-
-All good!
+Great! Anytime we'll install Python package, we'll do it in that environment.
 
 
 ## Python packages


### PR DESCRIPTION
@barangerbenjamin @gmanchon this reflects #36  suggestion to get rid of loading virtualenv from zsh but define a `global` virtualenv then `local`s virtualenvs. I also update the python version. We may go to the `3.9.0` as it is available with `pyenv`...