### PR TITLE
[vscode] use flake8 as default linter

### DIFF
--- a/LINUX.md
+++ b/LINUX.md
@@ -124,6 +124,8 @@ Paste the following just before the last `}`:
 },
 "python.pythonPath": "~/.pyenv/shims/python",
 "python.formatting.provider": "yapf",
+"python.linting.pylintEnabled": false,
+"python.linting.flake8Enabled": true,
 "workbench.settings.editor": "json",
 "workbench.settings.openDefaultSettings": true,
 "workbench.settings.useSplitJSON": true,

--- a/LINUX.md
+++ b/LINUX.md
@@ -124,6 +124,7 @@ Paste the following just before the last `}`:
 },
 "python.pythonPath": "~/.pyenv/shims/python",
 "python.formatting.provider": "yapf",
+"python.linting.enabled": true,
 "python.linting.pylintEnabled": false,
 "python.linting.flake8Enabled": true,
 "workbench.settings.editor": "json",

--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -526,6 +526,7 @@ Paste the following just before the last `}`:
 },
 "python.pythonPath": "~/.pyenv/shims/python",
 "python.formatting.provider": "yapf",
+"python.linting.enabled": true,
 "python.linting.pylintEnabled": false,
 "python.linting.flake8Enabled": true,
 "workbench.settings.editor": "json",

--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -526,6 +526,8 @@ Paste the following just before the last `}`:
 },
 "python.pythonPath": "~/.pyenv/shims/python",
 "python.formatting.provider": "yapf",
+"python.linting.pylintEnabled": false,
+"python.linting.flake8Enabled": true,
 "workbench.settings.editor": "json",
 "workbench.settings.openDefaultSettings": true,
 "workbench.settings.useSplitJSON": true,

--- a/_partials/vscode_setup.md
+++ b/_partials/vscode_setup.md
@@ -27,6 +27,7 @@ Paste the following just before the last `}`:
 },
 "python.pythonPath": "~/.pyenv/shims/python",
 "python.formatting.provider": "yapf",
+"python.linting.enabled": true,
 "python.linting.pylintEnabled": false,
 "python.linting.flake8Enabled": true,
 "workbench.settings.editor": "json",

--- a/_partials/vscode_setup.md
+++ b/_partials/vscode_setup.md
@@ -27,6 +27,8 @@ Paste the following just before the last `}`:
 },
 "python.pythonPath": "~/.pyenv/shims/python",
 "python.formatting.provider": "yapf",
+"python.linting.pylintEnabled": false,
+"python.linting.flake8Enabled": true,
 "workbench.settings.editor": "json",
 "workbench.settings.openDefaultSettings": true,
 "workbench.settings.useSplitJSON": true,

--- a/macOS.md
+++ b/macOS.md
@@ -252,6 +252,8 @@ Paste the following just before the last `}`:
 },
 "python.pythonPath": "~/.pyenv/shims/python",
 "python.formatting.provider": "yapf",
+"python.linting.pylintEnabled": false,
+"python.linting.flake8Enabled": true,
 "workbench.settings.editor": "json",
 "workbench.settings.openDefaultSettings": true,
 "workbench.settings.useSplitJSON": true,

--- a/macOS.md
+++ b/macOS.md
@@ -252,6 +252,7 @@ Paste the following just before the last `}`:
 },
 "python.pythonPath": "~/.pyenv/shims/python",
 "python.formatting.provider": "yapf",
+"python.linting.enabled": true,
 "python.linting.pylintEnabled": false,
 "python.linting.flake8Enabled": true,
 "workbench.settings.editor": "json",


### PR DESCRIPTION

use flake8 instead of pylint

syntax issues are highlighted whenever the file is saved
