### PR TITLE
Hints

### DIFF
--- a/LINUX.md
+++ b/LINUX.md
@@ -566,7 +566,28 @@ require(["codemirror/keymap/sublime", "notebook/js/cell", "base/js/namespace"],
 );
 ```
 
-You can close VS Code.
+### Custom CSS
+
+Improve the display of the [`details` disclosure elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details) in your notebooks.
+
+Open `custom/custom.css` in the config directory:
+```bash
+cd $JUPYTER_CONFIG_DIR
+touch custom/custom.css
+code custom/custom.css
+```
+Edit `custom.css` with:
+
+```css
+summary {
+    cursor: pointer;
+    display:list-item;
+}
+summary::marker {
+    font-size: 1em;
+}
+```
+
 
 ### `jupyter` check up
 Quit and restart your terminal first.
@@ -889,7 +910,7 @@ You can also sign in to Slack on your iPhone or Android device!
 
 The idea is that you'll have Slack open all day, so that you can share useful links / ask for help / decide where to go to lunch / etc.
 
-In case of remote tickets, you will use Slack audio or video call to get help. To ensure that everything is working fine, [test your camera and microphone](https://lewagon-alumni.slack.com/help/test/calls). If your browser is asking your permission to access your microphone and camera, click on yes.
+In case of remote tickets, you will use Slack audio or video call to get help. To ensure that everything is working fine, launch the Slack app on your Laptop, then [follow this procedure](https://slack.com/intl/en-gb/help/articles/115003538426-Troubleshoot-Slack-Calls#run-our-calls-test) (tl;dr type `/call --test` then the `Enter` key in any channel).
 
 After the test are finished, you should have green "All clear" messages at least for your microphone and camera. If not, ask a teacher.
 ![](images/slack_mic_cam_all_green.png)

--- a/LINUX.md
+++ b/LINUX.md
@@ -588,6 +588,7 @@ summary::marker {
 }
 ```
 
+You can close VS Code.
 
 ### `jupyter` check up
 Quit and restart your terminal first.

--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -1270,7 +1270,28 @@ require(["codemirror/keymap/sublime", "notebook/js/cell", "base/js/namespace"],
 );
 ```
 
-You can close VS Code.
+### Custom CSS
+
+Improve the display of the [`details` disclosure elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details) in your notebooks.
+
+Open `custom/custom.css` in the config directory:
+```bash
+cd $JUPYTER_CONFIG_DIR
+touch custom/custom.css
+code custom/custom.css
+```
+Edit `custom.css` with:
+
+```css
+summary {
+    cursor: pointer;
+    display:list-item;
+}
+summary::marker {
+    font-size: 1em;
+}
+```
+
 
 ### `jupyter` check up
 Quit and restart your terminal first.

--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -1292,6 +1292,7 @@ summary::marker {
 }
 ```
 
+You can close VS Code.
 
 ### `jupyter` check up
 Quit and restart your terminal first.

--- a/_partials/nbextensions.md
+++ b/_partials/nbextensions.md
@@ -64,6 +64,7 @@ summary::marker {
 }
 ```
 
+You can close <CODE_EDITOR>.
 
 ### `jupyter` check up
 Quit and restart your terminal first.

--- a/_partials/nbextensions.md
+++ b/_partials/nbextensions.md
@@ -42,7 +42,28 @@ require(["codemirror/keymap/sublime", "notebook/js/cell", "base/js/namespace"],
 );
 ```
 
-You can close <CODE_EDITOR>.
+### Custom CSS
+
+Improve the display of the [`details` disclosure elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details) in your notebooks.
+
+Open `custom/custom.css` in the config directory:
+```bash
+cd $JUPYTER_CONFIG_DIR
+touch custom/custom.css
+<CODE_EDITOR_CMD> custom/custom.css
+```
+Edit `custom.css` with:
+
+```css
+summary {
+    cursor: pointer;
+    display:list-item;
+}
+summary::marker {
+    font-size: 1em;
+}
+```
+
 
 ### `jupyter` check up
 Quit and restart your terminal first.

--- a/macOS.md
+++ b/macOS.md
@@ -783,7 +783,28 @@ require(["codemirror/keymap/sublime", "notebook/js/cell", "base/js/namespace"],
 );
 ```
 
-You can close VS Code.
+### Custom CSS
+
+Improve the display of the [`details` disclosure elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details) in your notebooks.
+
+Open `custom/custom.css` in the config directory:
+```bash
+cd $JUPYTER_CONFIG_DIR
+touch custom/custom.css
+code custom/custom.css
+```
+Edit `custom.css` with:
+
+```css
+summary {
+    cursor: pointer;
+    display:list-item;
+}
+summary::marker {
+    font-size: 1em;
+}
+```
+
 
 ### `jupyter` check up
 Quit and restart your terminal first.
@@ -1057,7 +1078,7 @@ You can also sign in to Slack on your iPhone or Android device!
 
 The idea is that you'll have Slack open all day, so that you can share useful links / ask for help / decide where to go to lunch / etc.
 
-In case of remote tickets, you will use Slack audio or video call to get help. To ensure that everything is working fine, [test your camera and microphone](https://lewagon-alumni.slack.com/help/test/calls). If your browser is asking your permission to access your microphone and camera, click on yes.
+In case of remote tickets, you will use Slack audio or video call to get help. To ensure that everything is working fine, launch the Slack app on your Laptop, then [follow this procedure](https://slack.com/intl/en-gb/help/articles/115003538426-Troubleshoot-Slack-Calls#run-our-calls-test) (tl;dr type `/call --test` then the `Enter` key in any channel).
 
 After the test are finished, you should have green "All clear" messages at least for your microphone and camera. If not, ask a teacher.
 ![](images/slack_mic_cam_all_green.png)

--- a/macOS.md
+++ b/macOS.md
@@ -805,6 +805,7 @@ summary::marker {
 }
 ```
 
+You can close VS Code.
 
 ### `jupyter` check up
 Quit and restart your terminal first.


### PR DESCRIPTION
This displays `details` disclosure natively in notebooks
<img width="122" alt="Screenshot 2021-04-20 at 12 47 22" src="https://user-images.githubusercontent.com/9978111/115404733-e5d20700-a1ed-11eb-9482-3aea9ed37183.png">
<img width="69" alt="Screenshot 2021-04-20 at 12 47 15" src="https://user-images.githubusercontent.com/9978111/115404735-e66a9d80-a1ed-11eb-8788-6758c19653ca.png">
