### PR TITLE
add chrome installation

### DIFF
--- a/LINUX.md
+++ b/LINUX.md
@@ -73,6 +73,17 @@ gh --version
 If you don't get a prompt saying `gh version X.Y.Z (YYYY-MM-DD)` with at least version 1.4, please refer to [the documentation](https://github.com/cli/cli/blob/trunk/docs/install_linux.md#official-sources) where they list some troubleshooting information. In doubt, ask a TA.
 
 
+## Chrome - your browser
+
+Install the Google Chrome browser if you haven't got it already and set it as a __default browser__.
+
+Follow the steps for your system from this link :point_right: [Install Google Chrome](https://support.google.com/chrome/answer/95346?co=GENIE.Platform%3DDesktop&hl=en-GB)
+
+__Why Chrome?__
+
+We recommend to use it as your default browser as it's most compatible with testing or running your code, as well as working with Google Cloud Platform. Another alternative is Firefox, however we don't recommend using other tools like Opera, Internet Explorer or Safari.
+
+
 ## Visual Studio Code - Your text editor
 
 A text editor is one of the most important tools of a developer.

--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -468,6 +468,17 @@ wsl -l -v
 
 
 
+## Chrome - your browser
+
+Install the Google Chrome browser if you haven't got it already and set it as a __default browser__.
+
+Follow the steps for your system from this link :point_right: [Install Google Chrome](https://support.google.com/chrome/answer/95346?co=GENIE.Platform%3DDesktop&hl=en-GB)
+
+__Why Chrome?__
+
+We recommend to use it as your default browser as it's most compatible with testing or running your code, as well as working with Google Cloud Platform. Another alternative is Firefox, however we don't recommend using other tools like Opera, Internet Explorer or Safari.
+
+
 ## Visual Studio Code
 
 We use Visual Code Studio for writing code on Windows, because it integrates nicely with the Ubuntu terminal.

--- a/_partials/chrome.md
+++ b/_partials/chrome.md
@@ -1,0 +1,9 @@
+## Chrome - your browser
+
+Install the Google Chrome browser if you haven't got it already and set it as a __default browser__.
+
+Follow the steps for your system from this link :point_right: [Install Google Chrome](https://support.google.com/chrome/answer/95346?co=GENIE.Platform%3DDesktop&hl=en-GB)
+
+__Why Chrome?__
+
+We recommend to use it as your default browser as it's most compatible with testing or running your code, as well as working with Google Cloud Platform. Another alternative is Firefox, however we don't recommend using other tools like Opera, Internet Explorer or Safari.

--- a/build.rb
+++ b/build.rb
@@ -10,6 +10,7 @@ MAC_OS = %w[
   setup/osx_command_line_tools
   setup/github
   homebrew
+  chrome
   mac_vscode
   vscode_setup
   setup/osx_oh_my_zsh
@@ -37,6 +38,7 @@ WINDOWS = %w[
   setup/github
   setup/remote_tools
   setup/wsl2_install_wsl
+  chrome
   setup/wsl2_vscode
   vscode_setup
   wsl2_vscode_settings
@@ -69,6 +71,7 @@ LINUX = %w[
   setup/remote_tools
   setup/github
   setup/ubuntu_git
+  chrome
   ubuntu_vscode
   vscode_setup
   setup/ubuntu_oh_my_zsh

--- a/macOS.md
+++ b/macOS.md
@@ -202,6 +202,17 @@ brew install --cask google-cloud-sdk
 ```
 
 
+## Chrome - your browser
+
+Install the Google Chrome browser if you haven't got it already and set it as a __default browser__.
+
+Follow the steps for your system from this link :point_right: [Install Google Chrome](https://support.google.com/chrome/answer/95346?co=GENIE.Platform%3DDesktop&hl=en-GB)
+
+__Why Chrome?__
+
+We recommend to use it as your default browser as it's most compatible with testing or running your code, as well as working with Google Cloud Platform. Another alternative is Firefox, however we don't recommend using other tools like Opera, Internet Explorer or Safari.
+
+
 ## Visual Studio Code - Your text editor
 
 1. Download [Visual Studio Code for macOS](https://go.microsoft.com/fwlink/?LinkID=534106).


### PR DESCRIPTION
Adding Chrome installation and setting it as default browser, related to [this issue](https://github.com/lewagon/data-challenges/issues/632) and multiple other problems resulting from Safari. 

Example: Compute Engine on GCP doesn't work properly with tools other than google (opening the new ssh connection).

Should we let the students follow the link or give explicit steps in the setup? It's pretty straightforward. WSL users should follow regular Windows installation, correct @barangerbenjamin ? 