### PR TITLE
[macos] split the gcloud CLI commands

### DIFF
--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -471,7 +471,7 @@ Then, let's disable warning for copy-pasting commands between Windows and Ubuntu
 
 :warning: Do not forget the comma at the end of the line!
 
-You can save these changes by pressing `CTRL` + `V`
+You can save these changes by pressing `CTRL` + `S`
 
 :heavy_check_mark: Your **Windows Terminal** is now setup :+1:
 

--- a/_partials/gcp_cli_setup.md
+++ b/_partials/gcp_cli_setup.md
@@ -1,6 +1,14 @@
+
 ## `gcloud` CLI
+
 Before Setting up our Google Cloud Platform account let's configure the `gcloud` CLI (A command line interface for Google Cloud Platform). Run the below and follow the terminal prompts to update your $PATH and enable shell command completion for the `.zshrc` file:
+
 ```bash
 brew install --cask google-cloud-sdk
+```
+
+Then you can:
+
+```bash
 /usr/local/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/install.sh
 ```

--- a/macOS.md
+++ b/macOS.md
@@ -717,10 +717,18 @@ You should get:
 ![](images/docker_info.png)
 
 
+
 ## `gcloud` CLI
+
 Before Setting up our Google Cloud Platform account let's configure the `gcloud` CLI (A command line interface for Google Cloud Platform). Run the below and follow the terminal prompts to update your $PATH and enable shell command completion for the `.zshrc` file:
+
 ```bash
 brew install --cask google-cloud-sdk
+```
+
+Then you can:
+
+```bash
 /usr/local/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/install.sh
 ```
 


### PR DESCRIPTION

split the commands so that the install command does not get fed to the password input of the brew command
