### PR TITLE
[macos] remove htop and tig

### DIFF
--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -471,7 +471,7 @@ Then, let's disable warning for copy-pasting commands between Windows and Ubuntu
 
 :warning: Do not forget the comma at the end of the line!
 
-You can save these changes by pressing `CTRL` + `V`
+You can save these changes by pressing `CTRL` + `S`
 
 :heavy_check_mark: Your **Windows Terminal** is now setup :+1:
 

--- a/_partials/homebrew.md
+++ b/_partials/homebrew.md
@@ -37,8 +37,6 @@ brew upgrade jq          || brew install jq
 brew upgrade openssl     || brew install openssl
 brew upgrade tree        || brew install tree
 brew upgrade ncdu        || brew install ncdu
-brew upgrade htop        || brew install htop
-brew upgrade tig         || brew install tig
 brew upgrade xz          || brew install xz
 brew upgrade readline    || brew install readline
 ```

--- a/macOS.md
+++ b/macOS.md
@@ -171,8 +171,6 @@ brew upgrade jq          || brew install jq
 brew upgrade openssl     || brew install openssl
 brew upgrade tree        || brew install tree
 brew upgrade ncdu        || brew install ncdu
-brew upgrade htop        || brew install htop
-brew upgrade tig         || brew install tig
 brew upgrade xz          || brew install xz
 brew upgrade readline    || brew install readline
 ```


### PR DESCRIPTION

`htop` and `tig` are not used during the bootcamp and `htop` causes setup issues

## context

students seem to run the htop install command as root after a warning displayed by the install command. This results in a `~/.config` directory created by root and unaccessible by the user. This triggers other errors

