### PR TITLE
Fall back 38x

### DIFF
--- a/LINUX.md
+++ b/LINUX.md
@@ -440,7 +440,7 @@ sudo apt install -y make build-essential libssl-dev zlib1g-dev libbz2-dev \
 Let's install the [latest stable version of Python](https://www.python.org/doc/versions/) supported by Le Wagon's curriculum:
 
 ```bash
-pyenv install 3.9.6
+pyenv install 3.8.12
 ```
 
 This command might take a while, this is perfectly normal. Don't hesitate to help other students seated next to you!
@@ -448,12 +448,12 @@ This command might take a while, this is perfectly normal. Don't hesitate to hel
 OK once this command is complete, we are going to tell the system to use this version of Python **by default**. This is done with:
 
 ```bash
-pyenv global 3.9.6
+pyenv global 3.8.12
 ```
 
 Once again, quit **all your opened terminal windows** (`Cmd` + `Q`) and restart one.
 
-To check if this worked, run `python --version`. If you see `3.9.6`, perfect! If not, ask a TA that will help you debug the problem thanks to `pyenv versions` and `type -a python` (`python` should be using the `.pyenv/shims` version first).
+To check if this worked, run `python --version`. If you see `3.8.12`, perfect! If not, ask a TA that will help you debug the problem thanks to `pyenv versions` and `type -a python` (`python` should be using the `.pyenv/shims` version first).
 
 
 ## Python Virtual Environment
@@ -471,7 +471,7 @@ Once again, quit **all your opened terminal windows** (`Cmd` + `Q`) and restart 
 Let's create the virtual environment we are going to use during the whole bootcamp:
 
 ```bash
-pyenv virtualenv 3.9.6 lewagon
+pyenv virtualenv 3.8.12 lewagon
 ```
 
 Let's now set the virtual environment with:
@@ -496,7 +496,7 @@ pip install --upgrade pip
 Then let's install some packages for the first weeks of the program:
 
 ```bash
-pip install -Ur https://raw.githubusercontent.com/lewagon/data-runner/py-3.9.6-pandas-1.3/requirements.txt
+pip install -Ur https://raw.githubusercontent.com/lewagon/data-runner/py-3.8.6-pandas-1.3/requirements.txt
 ```
 
 Finally, more Data Science packages:
@@ -517,7 +517,7 @@ pip install -U 'tensorflow<2.6'
 
 Check your Python version with the following commands:
 ```bash
-sh -c "$(curl -fsSL https://raw.githubusercontent.com/lewagon/data-setup/master/checks/python_checker.sh)" 3.9.6
+sh -c "$(curl -fsSL https://raw.githubusercontent.com/lewagon/data-setup/master/checks/python_checker.sh)" 3.8.12
 ```
 
 Run the following command to check if you successfully installed the required packages:

--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -889,7 +889,7 @@ sudo apt install -y make build-essential libssl-dev zlib1g-dev libbz2-dev \
 Let's install the [latest stable version of Python](https://www.python.org/doc/versions/) supported by Le Wagon's curriculum:
 
 ```bash
-pyenv install 3.9.6
+pyenv install 3.8.12
 ```
 
 This command might take a while, this is perfectly normal. Don't hesitate to help other students seated next to you!
@@ -897,12 +897,12 @@ This command might take a while, this is perfectly normal. Don't hesitate to hel
 OK once this command is complete, we are going to tell the system to use this version of Python **by default**. This is done with:
 
 ```bash
-pyenv global 3.9.6
+pyenv global 3.8.12
 ```
 
 Once again, quit **all your opened terminal windows** (`Cmd` + `Q`) and restart one.
 
-To check if this worked, run `python --version`. If you see `3.9.6`, perfect! If not, ask a TA that will help you debug the problem thanks to `pyenv versions` and `type -a python` (`python` should be using the `.pyenv/shims` version first).
+To check if this worked, run `python --version`. If you see `3.8.12`, perfect! If not, ask a TA that will help you debug the problem thanks to `pyenv versions` and `type -a python` (`python` should be using the `.pyenv/shims` version first).
 
 
 ## Python Virtual Environment
@@ -920,7 +920,7 @@ Once again, quit **all your opened terminal windows** (`Cmd` + `Q`) and restart 
 Let's create the virtual environment we are going to use during the whole bootcamp:
 
 ```bash
-pyenv virtualenv 3.9.6 lewagon
+pyenv virtualenv 3.8.12 lewagon
 ```
 
 Let's now set the virtual environment with:
@@ -945,7 +945,7 @@ pip install --upgrade pip
 Then let's install some packages for the first weeks of the program:
 
 ```bash
-pip install -Ur https://raw.githubusercontent.com/lewagon/data-runner/py-3.9.6-pandas-1.3/requirements.txt
+pip install -Ur https://raw.githubusercontent.com/lewagon/data-runner/py-3.8.6-pandas-1.3/requirements.txt
 ```
 
 Finally, more Data Science packages:
@@ -966,7 +966,7 @@ pip install -U 'tensorflow<2.6'
 
 Check your Python version with the following commands:
 ```bash
-sh -c "$(curl -fsSL https://raw.githubusercontent.com/lewagon/data-setup/master/checks/python_checker.sh)" 3.9.6
+sh -c "$(curl -fsSL https://raw.githubusercontent.com/lewagon/data-setup/master/checks/python_checker.sh)" 3.8.12
 ```
 
 Run the following command to check if you successfully installed the required packages:

--- a/build.rb
+++ b/build.rb
@@ -1,8 +1,7 @@
 #!/usr/bin/env ruby -wU
 CONSTANTS = {
     'PYTHON_VERSION' => "3.8.12",
-    'REQUIREMENTS_URL' => "https://raw.githubusercontent.com/lewagon/data-runner/py-3.8.6-pandas-1.3/requirements.txt",
-    'PYTHON_VERSION_URL' => "https://raw.githubusercontent.com/lewagon/data-setup/master/python_version.txt",
+    'REQUIREMENTS_URL' => "https://raw.githubusercontent.com/lewagon/data-runner/py-3.8.6-pandas-1.3/requirements.txt"
     'PYTHON_CHECKER_URL' => "https://raw.githubusercontent.com/lewagon/data-setup/master/checks/python_checker.sh",
     'PIP_CHECKER_URL' => "https://raw.githubusercontent.com/lewagon/data-setup/master/checks/pip_check.sh",
     'PIP_LOADER_URL' => "https://raw.githubusercontent.com/lewagon/data-setup/master/checks/pip_check.py"

--- a/build.rb
+++ b/build.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby -wU
 CONSTANTS = {
-    'PYTHON_VERSION' => "3.9.6",
-    'REQUIREMENTS_URL' => "https://raw.githubusercontent.com/lewagon/data-runner/py-3.9.6-pandas-1.3/requirements.txt",
+    'PYTHON_VERSION' => "3.8.12",
+    'REQUIREMENTS_URL' => "https://raw.githubusercontent.com/lewagon/data-runner/py-3.8.6-pandas-1.3/requirements.txt",
     'PYTHON_VERSION_URL' => "https://raw.githubusercontent.com/lewagon/data-setup/master/python_version.txt",
     'PYTHON_CHECKER_URL' => "https://raw.githubusercontent.com/lewagon/data-setup/master/checks/python_checker.sh",
     'PIP_CHECKER_URL' => "https://raw.githubusercontent.com/lewagon/data-setup/master/checks/pip_check.sh",

--- a/build.rb
+++ b/build.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby -wU
 CONSTANTS = {
     'PYTHON_VERSION' => "3.8.12",
-    'REQUIREMENTS_URL' => "https://raw.githubusercontent.com/lewagon/data-runner/py-3.8.6-pandas-1.3/requirements.txt"
+    'REQUIREMENTS_URL' => "https://raw.githubusercontent.com/lewagon/data-runner/py-3.8.6-pandas-1.3/requirements.txt",
     'PYTHON_CHECKER_URL' => "https://raw.githubusercontent.com/lewagon/data-setup/master/checks/python_checker.sh",
     'PIP_CHECKER_URL' => "https://raw.githubusercontent.com/lewagon/data-setup/master/checks/pip_check.sh",
     'PIP_LOADER_URL' => "https://raw.githubusercontent.com/lewagon/data-setup/master/checks/pip_check.py"

--- a/macOS.md
+++ b/macOS.md
@@ -503,7 +503,7 @@ Then quit **all your opened terminal windows** (`Cmd` + `Q`) and restart one.
 Let's install the [latest stable version of Python](https://www.python.org/doc/versions/) supported by Le Wagon's curriculum:
 
 ```bash
-pyenv install 3.9.6
+pyenv install 3.8.12
 ```
 
 This command might take a while, this is perfectly normal. Don't hesitate to help other students seated next to you!
@@ -528,7 +528,7 @@ export CPPFLAGS="-I/usr/local/opt/zlib/include"
 Then try to install Python again:
 
 ```bash
-pyenv install 3.9.6
+pyenv install 3.8.12
 ```
 
 It could raise another error about `bzip2`, you can ignore it and continue to the next step.
@@ -539,12 +539,12 @@ It could raise another error about `bzip2`, you can ignore it and continue to th
 OK once this command is complete, we are going to tell the system to use this version of Python **by default**. This is done with:
 
 ```bash
-pyenv global 3.9.6
+pyenv global 3.8.12
 ```
 
 Once again, quit **all your opened terminal windows** (`Cmd` + `Q`) and restart one.
 
-To check if this worked, run `python --version`. If you see `3.9.6`, perfect! If not, ask a TA that will help you debug the problem thanks to `pyenv versions` and `type -a python` (`python` should be using the `.pyenv/shims` version first).
+To check if this worked, run `python --version`. If you see `3.8.12`, perfect! If not, ask a TA that will help you debug the problem thanks to `pyenv versions` and `type -a python` (`python` should be using the `.pyenv/shims` version first).
 
 
 ## Python Virtual Environment
@@ -562,7 +562,7 @@ Once again, quit **all your opened terminal windows** (`Cmd` + `Q`) and restart 
 Let's create the virtual environment we are going to use during the whole bootcamp:
 
 ```bash
-pyenv virtualenv 3.9.6 lewagon
+pyenv virtualenv 3.8.12 lewagon
 ```
 
 Let's now set the virtual environment with:
@@ -587,7 +587,7 @@ pip install --upgrade pip
 Then let's install some packages for the first weeks of the program:
 
 ```bash
-pip install -Ur https://raw.githubusercontent.com/lewagon/data-runner/py-3.9.6-pandas-1.3/requirements.txt
+pip install -Ur https://raw.githubusercontent.com/lewagon/data-runner/py-3.8.6-pandas-1.3/requirements.txt
 ```
 
 Finally, more Data Science packages:
@@ -622,7 +622,7 @@ pip install -U tensorflow-macos tensorflow-metal
 
 Check your Python version with the following commands:
 ```bash
-sh -c "$(curl -fsSL https://raw.githubusercontent.com/lewagon/data-setup/master/checks/python_checker.sh)" 3.9.6
+sh -c "$(curl -fsSL https://raw.githubusercontent.com/lewagon/data-setup/master/checks/python_checker.sh)" 3.8.12
 ```
 
 Run the following command to check if you successfully installed the required packages:


### PR DESCRIPTION
this downgrades Python to `3.8.12` to be compliant with TF setup for M1 chips 