### PR TITLE
use docker wsl2 backend

### DIFF
--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -1191,28 +1191,19 @@ _if you already have Docker installed on your machine please update with the lat
 
 Go to [Docker for WSL2](https://docs.docker.com/docker-for-windows/wsl/).
 
-Then follow the tutorial instructions to install Docker **using the repository**. There are 2 steps:
+Download and install the Docker Desktop WSL 2 backend.
 
-- SET UP THE REPOSITORY
-- INSTALL DOCKER ENGINE
+Once done, start Docker.
 
-Once done, you should be able to run:
-
-```bash
-sudo service docker start
-```
+You should be able to run in a Ubuntu terminal:
 
 ```bash
-sudo docker run hello-world
+docker run hello-world
 ```
 
 The following message should print:
 
 ![](images/docker_hello.png)
-
-```bash
-sudo service docker stop
-```
 
 
 ## Google Cloud Platform setup

--- a/_partials/ubuntu_docker.md
+++ b/_partials/ubuntu_docker.md
@@ -6,12 +6,7 @@ _if you already have Docker installed on your machine please update with the lat
 
 ### Install Docker
 
-$WINDOWS_START
-Go to [Docker for WSL2](https://docs.docker.com/docker-for-windows/wsl/).
-$WINDOWS_END
-$LINUX_START
 Go to [Docker install documentation](https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository).
-$LINUX_END
 
 Then follow the tutorial instructions to install Docker **using the repository**. There are 2 steps:
 

--- a/_partials/win_docker.md
+++ b/_partials/win_docker.md
@@ -1,0 +1,23 @@
+## Docker 🐋
+
+Docker is an open platform for developing, shipping, and running applications.
+
+_if you already have Docker installed on your machine please update with the latest version_
+
+### Install Docker
+
+Go to [Docker for WSL2](https://docs.docker.com/docker-for-windows/wsl/).
+
+Download and install the Docker Desktop WSL 2 backend.
+
+Once done, start Docker.
+
+You should be able to run in a Ubuntu terminal:
+
+```bash
+docker run hello-world
+```
+
+The following message should print:
+
+![](images/docker_hello.png)

--- a/build.rb
+++ b/build.rb
@@ -77,7 +77,7 @@ WINDOWS = %w[
   nbextensions
   setup/windows_settings
   win_vs_redistributable
-  ubuntu_docker
+  win_docker
   gcp_setup
   gcp_setup_wsl
   gcp_setup_end


### PR DESCRIPTION

update the windows instructions to use Docker Desktop WSL2 backend

the Docker app can be started and stopped in Windows as in the Mac setup

the docker command is made available in Ubuntu without having to `sudo`
