### PR TITLE
remove tensorflow-metal

### DIFF
--- a/build.rb
+++ b/build.rb
@@ -2,7 +2,7 @@
 CONSTANTS = {
     'PYTHON_VERSION' => "3.8.12",
     'TENSORFLOW_TOP_VERSION' => "tensorflow<2.6",
-    'APPLE_SILICON_TENSORFLOW_PACKAGES' => "tensorflow-macos tensorflow-metal",
+    'APPLE_SILICON_TENSORFLOW_PACKAGES' => "tensorflow-macos",
     'BOOTCAMP_COMPLETE_REQUIREMENTS' => "yapf jupyterlab seaborn plotly nbconvert xgboost statsmodels pandas-profiling dtale jupyter-resource-usage jupyter_contrib_nbextensions",
     'REQUIREMENTS_URL' => "https://raw.githubusercontent.com/lewagon/data-runner/py-3.8.12-pandas-1.3-async-v2/requirements.txt",
     'PYTHON_CHECKER_URL' => "https://raw.githubusercontent.com/lewagon/data-setup/master/checks/python_checker.sh",

--- a/macOS.md
+++ b/macOS.md
@@ -618,7 +618,7 @@ pip install -U 'tensorflow<2.6'
     <summary>Setup for Apple Silicon chips</summary>
 
 ```bash
-pip install -U tensorflow-macos tensorflow-metal
+pip install -U tensorflow-macos
 ```
 
 </details>

--- a/macOS_keep_current.md
+++ b/macOS_keep_current.md
@@ -157,7 +157,7 @@ pip install -U 'tensorflow<2.6'
     <summary>Setup for Apple Silicon chips</summary>
 
 ```bash
-pip install -U tensorflow-macos tensorflow-metal
+pip install -U tensorflow-macos
 ```
 
 </details>


### PR DESCRIPTION
This removes`tensorflow-metal` from the setup as it causes bugs when trying to train RNN. It appears RNN try to use GPU but fails.
Trace:
```
InvalidArgumentError: 2 root error(s) found.
  (0) Invalid argument:  No OpKernel was registered to support Op 'CudnnRNNV3' used by {{node cond_40/then/_0/cond/CudnnRNNV3}} with these attrs: [T=DT_FLOAT, input_mode="linear_input", direction="unidirectional", rnn_mode="lstm", is_training=true, seed2=0, num_proj=0, time_major=false, dropout=0, seed=0]
Registered devices: [CPU, GPU]
Registered kernels:
  <no registered kernels>

	 [[cond_40/then/_0/cond/CudnnRNNV3]]
	 [[sequential_6/lstm_3/PartitionedCall]]
	 [[binary_crossentropy/logistic_loss/_22]]
  (1) Invalid argument:  No OpKernel was registered to support Op 'CudnnRNNV3' used by {{node cond_40/then/_0/cond/CudnnRNNV3}} with these attrs: [T=DT_FLOAT, input_mode="linear_input", direction="unidirectional", rnn_mode="lstm", is_training=true, seed2=0, num_proj=0, time_major=false, dropout=0, seed=0]
Registered devices: [CPU, GPU]
Registered kernels:
  <no registered kernels>

	 [[cond_40/then/_0/cond/CudnnRNNV3]]
	 [[sequential_6/lstm_3/PartitionedCall]]
0 successful operations.
0 derived errors ignored. [Op:__inference_train_function_82445]

Function call stack:
train_function -> train_function
```