### PR TITLE
force tensorflow-macos version below 2.6

### DIFF
--- a/LINUX.md
+++ b/LINUX.md
@@ -142,7 +142,7 @@ These commands will ask for your password: type it in.
 
 :warning: When you type your password, nothing will show up on the screen, **that's normal**. This is a security feature to mask not only your password as a whole but also its length. Just type in your password and when you're done, press `ENTER`.
 
-### GitHub CLI
+### GitHub CLI installation
 
 Let's now install [GitHub official CLI](https://cli.github.com) (Command Line Interface). It's a software used to interact with your GitHub account via the command line.
 
@@ -189,7 +189,7 @@ Instead of using the default `bash` [shell](https://en.wikipedia.org/wiki/Shell_
 In a terminal execute the following command and type in your password if asked:
 
 ```bash
-sudo apt install -y zsh curl vim imagemagick jq
+sudo apt install -y zsh curl vim imagemagick jq unzip
 ```
 
 
@@ -284,7 +284,7 @@ understanding of what those keys are used for.
 
 CLI is the acronym of [Command-line Interface](https://en.wikipedia.org/wiki/Command-line_interface).
 
-In this section, we will install [GitHub CLI](https://cli.github.com/) to perform useful actions with GitHub data directly from the terminal.
+In this section, we will use [GitHub CLI](https://cli.github.com/) to perform interact with GitHub directly from the terminal.
 
 It should already be installed on your computer from the previous commands.
 

--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -520,7 +520,7 @@ These commands will ask for your password: type it in.
 
 :warning: When you type your password, nothing will show up on the screen, **that's normal**. This is a security feature to mask not only your password as a whole but also its length. Just type in your password and when you're done, press `ENTER`.
 
-### GitHub CLI
+### GitHub CLI installation
 
 Let's now install [GitHub official CLI](https://cli.github.com) (Command Line Interface). It's a software used to interact with your GitHub account via the command line.
 
@@ -556,7 +556,7 @@ Instead of using the default `bash` [shell](https://en.wikipedia.org/wiki/Shell_
 In a terminal execute the following command and type in your password if asked:
 
 ```bash
-sudo apt install -y zsh curl vim imagemagick jq
+sudo apt install -y zsh curl vim imagemagick jq unzip
 ```
 
 
@@ -726,7 +726,7 @@ If it does not,
 
 CLI is the acronym of [Command-line Interface](https://en.wikipedia.org/wiki/Command-line_interface).
 
-In this section, we will install [GitHub CLI](https://cli.github.com/) to perform useful actions with GitHub data directly from the terminal.
+In this section, we will use [GitHub CLI](https://cli.github.com/) to perform interact with GitHub directly from the terminal.
 
 It should already be installed on your computer from the previous commands.
 

--- a/build.rb
+++ b/build.rb
@@ -2,7 +2,7 @@
 CONSTANTS = {
     'PYTHON_VERSION' => "3.8.12",
     'TENSORFLOW_TOP_VERSION' => "tensorflow<2.6",
-    'APPLE_SILICON_TENSORFLOW_PACKAGES' => "tensorflow-macos",
+    'APPLE_SILICON_TENSORFLOW_PACKAGES' => "tensorflow-macos<2.6",
     'BOOTCAMP_COMPLETE_REQUIREMENTS' => "yapf jupyterlab seaborn plotly nbconvert xgboost statsmodels pandas-profiling dtale jupyter-resource-usage jupyter_contrib_nbextensions",
     'REQUIREMENTS_URL' => "https://raw.githubusercontent.com/lewagon/data-runner/py-3.8.12-pandas-1.3-async-v2/requirements.txt",
     'PYTHON_CHECKER_URL' => "https://raw.githubusercontent.com/lewagon/data-setup/master/checks/python_checker.sh",

--- a/macOS.md
+++ b/macOS.md
@@ -348,7 +348,7 @@ understanding of what those keys are used for.
 
 CLI is the acronym of [Command-line Interface](https://en.wikipedia.org/wiki/Command-line_interface).
 
-In this section, we will install [GitHub CLI](https://cli.github.com/) to perform useful actions with GitHub data directly from the terminal.
+In this section, we will use [GitHub CLI](https://cli.github.com/) to perform interact with GitHub directly from the terminal.
 
 It should already be installed on your computer from the previous commands.
 
@@ -618,7 +618,7 @@ pip install -U 'tensorflow<2.6'
     <summary>Setup for Apple Silicon chips</summary>
 
 ```bash
-pip install -U tensorflow-macos
+pip install -U tensorflow-macos<2.6
 ```
 
 </details>

--- a/macOS_keep_current.md
+++ b/macOS_keep_current.md
@@ -157,7 +157,7 @@ pip install -U 'tensorflow<2.6'
     <summary>Setup for Apple Silicon chips</summary>
 
 ```bash
-pip install -U tensorflow-macos
+pip install -U tensorflow-macos<2.6
 ```
 
 </details>


### PR DESCRIPTION
Aligned with non-M1 version
This solves incompatibilities with pylint.