### PR TITLE
add dbeaver to the setup

### DIFF
--- a/LINUX.md
+++ b/LINUX.md
@@ -647,6 +647,12 @@ Untick _"disable configuration for nbextensions without explicit compatibility"_
 You can close your web browser then terminate the jupyter server with `CTRL` + `C`.
 
 
+
+## DBeaver
+
+Download and install [DBeaver](https://dbeaver.io/), a free and open source powerful tool to connect to any database, explore the schema and even **run SQL queries**.
+
+
 ## Docker 🐋
 
 Docker is an open platform for developing, shipping, and running applications.

--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -1133,6 +1133,12 @@ Untick _"disable configuration for nbextensions without explicit compatibility"_
 You can close your web browser then terminate the jupyter server with `CTRL` + `C`.
 
 
+
+## DBeaver
+
+Download and install [DBeaver](https://dbeaver.io/), a free and open source powerful tool to connect to any database, explore the schema and even **run SQL queries**.
+
+
 ## Windows settings
 
 ### Exchange files between Windows and Ubuntu

--- a/_partials/dbeaver.md
+++ b/_partials/dbeaver.md
@@ -1,0 +1,4 @@
+
+## DBeaver
+
+Download and install [DBeaver](https://dbeaver.io/), a free and open source powerful tool to connect to any database, explore the schema and even **run SQL queries**.

--- a/build.rb
+++ b/build.rb
@@ -31,6 +31,7 @@ MAC_OS = %w[
   pip
   python_checkup
   nbextensions
+  dbeaver
   docker
   gcp_cli_setup
   gcp_setup
@@ -75,6 +76,7 @@ WINDOWS = %w[
   python_checkup
   win_jupyter
   nbextensions
+  dbeaver
   setup/windows_settings
   win_vs_redistributable
   win_docker
@@ -113,6 +115,7 @@ LINUX = %w[
   pip
   python_checkup
   nbextensions
+  dbeaver
   ubuntu_docker
   gcp_setup
   gcp_setup_linux

--- a/macOS.md
+++ b/macOS.md
@@ -754,6 +754,12 @@ Untick _"disable configuration for nbextensions without explicit compatibility"_
 You can close your web browser then terminate the jupyter server with `CTRL` + `C`.
 
 
+
+## DBeaver
+
+Download and install [DBeaver](https://dbeaver.io/), a free and open source powerful tool to connect to any database, explore the schema and even **run SQL queries**.
+
+
 ## Docker 🐋
 
 Docker is an open platform for developing, shipping, and running applications.


### PR DESCRIPTION
nothing much to add to this partial at the moment

this partial is there so that the issues of future B2B students with specific setup contraints are addressed beforehand

we encountered the case of a student with a laptop unable to install DBeaver because they could not install a recent JVM

```
Incompatible JVM

Version 1.8.0_251 of the JVM is not suitable for this product. Version: 11 or greater is required.
```

note: `ruby build.rb` currently has timeouts when fetching partials from the web setup
