### PR TITLE
add python-dev dependencies for Prophet

### DIFF
--- a/LINUX.md
+++ b/LINUX.md
@@ -493,7 +493,8 @@ Let's install some [dependencies](https://github.com/pyenv/pyenv/wiki/common-bui
 ```bash
 sudo apt-get update; sudo apt-get install make build-essential libssl-dev zlib1g-dev \
 libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \
-libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
+libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev \
+python-dev python3-dev
 ```
 
 Let's install the [latest stable version of Python](https://www.python.org/doc/versions/) supported by Le Wagon's curriculum:

--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -932,7 +932,8 @@ Let's install some [dependencies](https://github.com/pyenv/pyenv/wiki/common-bui
 ```bash
 sudo apt-get update; sudo apt-get install make build-essential libssl-dev zlib1g-dev \
 libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \
-libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
+libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev \
+python-dev python3-dev
 ```
 
 Let's install the [latest stable version of Python](https://www.python.org/doc/versions/) supported by Le Wagon's curriculum:

--- a/_partials/ubuntu_python.md
+++ b/_partials/ubuntu_python.md
@@ -15,7 +15,8 @@ Let's install some [dependencies](https://github.com/pyenv/pyenv/wiki/common-bui
 ```bash
 sudo apt-get update; sudo apt-get install make build-essential libssl-dev zlib1g-dev \
 libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \
-libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
+libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev \
+python-dev python3-dev
 ```
 
 Let's install the [latest stable version of Python](https://www.python.org/doc/versions/) supported by Le Wagon's curriculum:


### PR DESCRIPTION
this 2 dependencies are required to run Facebook Prophet Python package on Ubuntu