### PR TITLE
fix link to apple_intel.txt and apple_silicon.txt

### DIFF
--- a/macOS_keep_current.md
+++ b/macOS_keep_current.md
@@ -146,7 +146,7 @@ If your computer uses **Apple Silicon**, expand the paragraph below and go throu
   <summary>👉&nbsp;&nbsp;Setup for Apple Silicon 👈</summary>
 
 ``` bash
-pip install -r https://raw.githubusercontent.com/lewagon/data-setup/specs/releases/apple_silicon.txt
+pip install -r https://raw.githubusercontent.com/lewagon/data-setup/master/specs/releases/apple_silicon.txt
 ```
 </details>
 
@@ -156,7 +156,7 @@ If your computer uses **Apple Intel**, expand the paragraph below and go through
   <summary>👉&nbsp;&nbsp;Setup for Apple Intel 👈</summary>
 
 ``` bash
-pip install -r https://raw.githubusercontent.com/lewagon/data-setup/specs/releases/apple_intel.txt
+pip install -r https://raw.githubusercontent.com/lewagon/data-setup/master/specs/releases/apple_intel.txt
 ```
 </details>
 


### PR DESCRIPTION
Link to the package lists in the macos keep current setup were broken ('master' was missing in the path). 

E.g. was:
[https://raw.githubusercontent.com/lewagon/data-setup/specs/releases/apple_intel.txt](url)
which can't be found

Is now:
[https://raw.githubusercontent.com/lewagon/data-setup/master/specs/releases/apple_intel.txt](url)
which works.

Hope it was okay to simply make a pull request. Making an issue for such a minor and quickly fixed thing seemed silly. 