### PR TITLE
22q4 setup bug bash

### DIFF
--- a/LINUX.md
+++ b/LINUX.md
@@ -125,19 +125,21 @@ Click on the little arrow at the bottom of the left bar :point_down:
 That's it, you're good to go!
 
 
-## Git
+## Command line tools
 
-### Installation
+### Zsh & Git
 
-[`git`](https://git-scm.com/) is a command line software used for version control.
+Instead of using the default `bash` [shell](https://en.wikipedia.org/wiki/Shell_(computing)), we will use `zsh`.
 
-To install `git`:
+We will also use [`git`](https://git-scm.com/), a command line software used for version control.
+
+Let's install them, along with other useful tools:
 - Open a terminal
 - Copy and paste the following commands:
 
 ```bash
 sudo apt update
-sudo apt install -y git
+sudo apt install -y curl git imagemagick jq unzip vim zsh
 ```
 
 These commands will ask for your password: type it in.
@@ -179,17 +181,6 @@ __Why Chrome?__
 We recommend to use it as your default browser as it's most compatible with testing or running your code, as well as working with Google Cloud Platform. Another alternative is Firefox, however we don't recommend using other tools like Opera, Internet Explorer or Safari.
 
 
-## zsh
-
-Instead of using the default `bash` [shell](https://en.wikipedia.org/wiki/Shell_(computing)), we will use `zsh`.
-
-In a terminal execute the following command and type in your password if asked:
-
-```bash
-sudo apt install -y zsh curl vim imagemagick jq unzip
-```
-
-
 ## Oh-my-zsh
 
 Let's install the `zsh` plugin [Oh My Zsh](https://ohmyz.sh/).
@@ -227,18 +218,30 @@ First in order to **login**, copy-paste the following command in your terminal:
 gh auth login -s 'user:email' -w
 ```
 
-You will get the following output:
+gh will ask you few questions:
+
+`What is your preferred protocol for Git operations?` With the arrows, choose `SSH` and press `Enter`. SSH is a protocol to log in using SSH keys instead of the well known username/password pair.
+
+`Generate a new SSH key to add to your GitHub account?` Press `Enter` to ask gh to generate the SSH keys for you.
+
+If you already have SSH keys, you will see instead `Upload your SSH public key to your GitHub account?` With the arrows, select your public key file path and press `Enter`.
+
+`Enter a passphrase for your new SSH key (Optional)`. Type something you want and that you'll remember. It's a password to protect your private key stored on your hard drive. Then press `Enter`.
+
+:warning: When you type your passphrase, nothing will show up on the screen, **that's normal**. This is a security feature to mask not only your passphrase as a whole but also its length. Just type your passphrase and when you're done, press `Enter`.
+
+You will then get the following output:
 
 ```bash
 ! First copy your one-time code: 0EF9-D015
 - Press Enter to open github.com in your browser...
 ```
 
-Select and copy the code (`0EF9-D015` in the example), then press `ENTER`.
+Select and copy the code (`0EF9-D015` in the example), then press `Enter`.
 
 Your browser will open and ask you to authorize GitHub CLI to use your GitHub account. Accept and wait a bit.
 
-Come back to the terminal, press `ENTER` again, and that's it.
+Come back to the terminal, press `Enter` again, and that's it.
 
 To check that you are properly connected, type:
 
@@ -249,53 +252,6 @@ gh auth status
 :heavy_check_mark: If you get `Logged in to github.com as <YOUR USERNAME> `, then all good :+1:
 
 :x: If not, **contact a teacher**.
-
-Then run the following configuration line:
-
-```bash
-gh config set git_protocol ssh
-```
-
-
-## SSH Key
-
-### Generation
-
-We need to generate SSH keys which are going to be used by GitHub to authenticate you. You can think of it as a way to log in, but different from the well known username/password pair.
-
-:warning: If you already generated keys that you already use with other services, you can skip this step.
-
-Open a terminal and copy-paste this command, replacing the email with **yours** (the same one you used to create your GitHub account).
-
-```bash
-mkdir -p ~/.ssh && ssh-keygen -t ed25519 -o -a 100 -f ~/.ssh/id_ed25519 -C "TYPE_YOUR_EMAIL@HERE.com"
-```
-
-It will prompt for information. Just press enter until it asks for a **passphrase**.
-
-:warning: When asked for a passphrase, put something you want and that you'll remember. It's a password to protect your private key stored on your hard drive.
-
-:warning: When you type your passphrase, nothing will show up on the screen, **that's normal**. This is a security feature to mask not only your passphrase as a whole but also its length. Just type your passphrase and when you're done, press `ENTER`.
-
-### Giving your public key to GitHub
-
-Now, you will give your **public** key to GitHub.
-
-In your terminal copy-paste the following command:
-
-```bash
-gh auth refresh -s write:public_key
-```
-
-It will prompt a one time code (####-####) on the screen. Copy it and press `ENTER`, then paste the code in your browser and follow the instructions to **Authorize GitHub**.
-
-Back in the terminal, press `ENTER` and run this:
-
-```bash
-gh ssh-key add ~/.ssh/id_ed25519.pub
-```
-
-This should return `✓ Public key added to your account`. If not, do not hesitate to **contact a teacher**.
 
 
 ## Google Cloud CLI

--- a/LINUX.md
+++ b/LINUX.md
@@ -66,7 +66,7 @@ sudo apt install -y code
 
 These commands will ask for your password: type it in.
 
-:warning: When you type your password, nothing will show up on the screen, **that's normal**. This is a security feature to mask not only your password as a whole but also its length. Just type in your password and when you're done, press `ENTER`.
+:warning: When you type your password, nothing will show up on the screen, **that's normal**. This is a security feature to mask not only your password as a whole but also its length. Just type in your password and when you're done, press `Enter`.
 
 ### Launching from the terminal
 
@@ -111,7 +111,7 @@ Here is a list of the extensions you are installing:
 
 [Visual Studio Live Share](https://visualstudio.microsoft.com/services/live-share/) is a VS Code extension which allows you to share the code in your text editor for debugging and pair-programming: let's set it up!
 
-Launch VS Code from your terminal by typing `code` and pressing `ENTER`.
+Launch VS Code from your terminal by typing `code` and pressing `Enter`.
 
 Click on the little arrow at the bottom of the left bar :point_down:
 
@@ -144,7 +144,7 @@ sudo apt install -y curl git imagemagick jq unzip vim zsh
 
 These commands will ask for your password: type it in.
 
-:warning: When you type your password, nothing will show up on the screen, **that's normal**. This is a security feature to mask not only your password as a whole but also its length. Just type in your password and when you're done, press `ENTER`.
+:warning: When you type your password, nothing will show up on the screen, **that's normal**. This is a security feature to mask not only your password as a whole but also its length. Just type in your password and when you're done, press `Enter`.
 
 ### GitHub CLI installation
 
@@ -964,7 +964,7 @@ The idea is that you'll have Slack open all day, so that you can share useful li
 
 To ensure that everything is working fine for video calls, let's test your camera and microphone:
 - Open the Slack app
-- In any channel message bar type `/call --test` and press `ENTER`
+- In any channel message bar type `/call --test` and press `Enter`
 - Click on the "Start test" green button
 
 ![Check microphone and webcam with Slack](https://github.com/lewagon/setup/blob/master/images/slack_call_test.png)

--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -323,7 +323,7 @@ At first launch, you will be asked some information:
 - Choose a **password**
 - Confirm your password
 
-:warning: When you type your password, nothing will show up on the screen, **that's normal**. This is a security feature to mask not only your password as a whole but also its length. Just type your password and when you're done, press `ENTER`.
+:warning: When you type your password, nothing will show up on the screen, **that's normal**. This is a security feature to mask not only your password as a whole but also its length. Just type your password and when you're done, press `Enter`.
 
 You can close the Ubuntu window now that it is installed on your computer.
 
@@ -538,7 +538,7 @@ Here is a list of the extensions you are installing:
 
 [Visual Studio Live Share](https://visualstudio.microsoft.com/services/live-share/) is a VS Code extension which allows you to share the code in your text editor for debugging and pair-programming: let's set it up!
 
-Launch VS Code from your terminal by typing `code` and pressing `ENTER`.
+Launch VS Code from your terminal by typing `code` and pressing `Enter`.
 
 Click on the little arrow at the bottom of the left bar :point_down:
 
@@ -571,7 +571,7 @@ sudo apt install -y curl git imagemagick jq unzip vim zsh
 
 These commands will ask for your password: type it in.
 
-:warning: When you type your password, nothing will show up on the screen, **that's normal**. This is a security feature to mask not only your password as a whole but also its length. Just type in your password and when you're done, press `ENTER`.
+:warning: When you type your password, nothing will show up on the screen, **that's normal**. This is a security feature to mask not only your password as a whole but also its length. Just type in your password and when you're done, press `Enter`.
 
 ### GitHub CLI installation
 
@@ -1537,7 +1537,7 @@ The idea is that you'll have Slack open all day, so that you can share useful li
 
 To ensure that everything is working fine for video calls, let's test your camera and microphone:
 - Open the Slack app
-- In any channel message bar type `/call --test` and press `ENTER`
+- In any channel message bar type `/call --test` and press `Enter`
 - Click on the "Start test" green button
 
 ![Check microphone and webcam with Slack](https://github.com/lewagon/setup/blob/master/images/slack_call_test.png)

--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -72,7 +72,7 @@ To check your Windows version:
   - When the installation is over, execute the commands above :point_up: to check that you now have **Windows 10**.
 </details>
 
-:information_source: [Windows 11 upgrade is rolling now](https://www.microsoft.com/en-us/windows/get-windows-11), which means it may or may not be available for your computer just yet.
+:information_source: [Windows 11 upgrade is rolling out now](https://www.microsoft.com/en-us/windows/get-windows-11), which means it may or may not be available for your computer just yet.
 
 :warning: **If you have Windows 10 installed, you don't need to upgrade to Windows 11 to proceed with this setup**.
 
@@ -552,19 +552,21 @@ Click on the little arrow at the bottom of the left bar :point_down:
 That's it, you're good to go!
 
 
-## Git
+## Command line tools
 
-### Installation
+### Zsh & Git
 
-[`git`](https://git-scm.com/) is a command line software used for version control.
+Instead of using the default `bash` [shell](https://en.wikipedia.org/wiki/Shell_(computing)), we will use `zsh`.
 
-To install `git`:
+We will also use [`git`](https://git-scm.com/), a command line software used for version control.
+
+Let's install them, along with other useful tools:
 - Open a terminal
 - Copy and paste the following commands:
 
 ```bash
 sudo apt update
-sudo apt install -y git
+sudo apt install -y curl git imagemagick jq unzip vim zsh
 ```
 
 These commands will ask for your password: type it in.
@@ -593,17 +595,6 @@ gh --version
 :heavy_check_mark: If you see `gh version X.Y.Z (YYYY-MM-DD)`, you're good to go :+1:
 
 :x: Otherwise, please **contact a teacher**
-
-
-## zsh
-
-Instead of using the default `bash` [shell](https://en.wikipedia.org/wiki/Shell_(computing)), we will use `zsh`.
-
-In a terminal execute the following command and type in your password if asked:
-
-```bash
-sudo apt install -y zsh curl vim imagemagick jq unzip
-```
 
 
 ## Oh-my-zsh
@@ -643,18 +634,30 @@ First in order to **login**, copy-paste the following command in your terminal:
 gh auth login -s 'user:email' -w
 ```
 
-You will get the following output:
+gh will ask you few questions:
+
+`What is your preferred protocol for Git operations?` With the arrows, choose `SSH` and press `Enter`. SSH is a protocol to log in using SSH keys instead of the well known username/password pair.
+
+`Generate a new SSH key to add to your GitHub account?` Press `Enter` to ask gh to generate the SSH keys for you.
+
+If you already have SSH keys, you will see instead `Upload your SSH public key to your GitHub account?` With the arrows, select your public key file path and press `Enter`.
+
+`Enter a passphrase for your new SSH key (Optional)`. Type something you want and that you'll remember. It's a password to protect your private key stored on your hard drive. Then press `Enter`.
+
+:warning: When you type your passphrase, nothing will show up on the screen, **that's normal**. This is a security feature to mask not only your passphrase as a whole but also its length. Just type your passphrase and when you're done, press `Enter`.
+
+You will then get the following output:
 
 ```bash
 ! First copy your one-time code: 0EF9-D015
 - Press Enter to open github.com in your browser...
 ```
 
-Select and copy the code (`0EF9-D015` in the example), then press `ENTER`.
+Select and copy the code (`0EF9-D015` in the example), then press `Enter`.
 
 Your browser will open and ask you to authorize GitHub CLI to use your GitHub account. Accept and wait a bit.
 
-Come back to the terminal, press `ENTER` again, and that's it.
+Come back to the terminal, press `Enter` again, and that's it.
 
 To check that you are properly connected, type:
 
@@ -665,53 +668,6 @@ gh auth status
 :heavy_check_mark: If you get `Logged in to github.com as <YOUR USERNAME> `, then all good :+1:
 
 :x: If not, **contact a teacher**.
-
-Then run the following configuration line:
-
-```bash
-gh config set git_protocol ssh
-```
-
-
-## SSH Key
-
-### Generation
-
-We need to generate SSH keys which are going to be used by GitHub to authenticate you. You can think of it as a way to log in, but different from the well known username/password pair.
-
-:warning: If you already generated keys that you already use with other services, you can skip this step.
-
-Open a terminal and copy-paste this command, replacing the email with **yours** (the same one you used to create your GitHub account).
-
-```bash
-mkdir -p ~/.ssh && ssh-keygen -t ed25519 -o -a 100 -f ~/.ssh/id_ed25519 -C "TYPE_YOUR_EMAIL@HERE.com"
-```
-
-It will prompt for information. Just press enter until it asks for a **passphrase**.
-
-:warning: When asked for a passphrase, put something you want and that you'll remember. It's a password to protect your private key stored on your hard drive.
-
-:warning: When you type your passphrase, nothing will show up on the screen, **that's normal**. This is a security feature to mask not only your passphrase as a whole but also its length. Just type your passphrase and when you're done, press `ENTER`.
-
-### Giving your public key to GitHub
-
-Now, you will give your **public** key to GitHub.
-
-In your terminal copy-paste the following command:
-
-```bash
-gh auth refresh -s write:public_key
-```
-
-It will prompt a one time code (####-####) on the screen. Copy it and press `ENTER`, then paste the code in your browser and follow the instructions to **Authorize GitHub**.
-
-Back in the terminal, press `ENTER` and run this:
-
-```bash
-gh ssh-key add ~/.ssh/id_ed25519.pub
-```
-
-This should return `✓ Public key added to your account`. If not, do not hesitate to **contact a teacher**.
 
 
 ## Google Cloud CLI

--- a/build.rb
+++ b/build.rb
@@ -160,7 +160,7 @@ def load_partial(partial, locale)
   file = File.join("_partials", "#{partial}.md")
   if match_data
     require 'open-uri'
-    content = URI.open(File.join("https://raw.githubusercontent.com/lewagon/setup/22q4-setup-bug-bash", file))
+    content = URI.open(File.join("https://raw.githubusercontent.com/lewagon/setup/master", file))
             .string
     # replace data-setup repo relative path by setup repo URL
     image_paths = content.scan(/\!\[.*\]\((.*)\)/).flatten

--- a/build.rb
+++ b/build.rb
@@ -22,7 +22,6 @@ MAC_OS = %w[
   setup/vscode_liveshare
   setup/oh_my_zsh
   setup/gh_cli
-  setup/ssh_key
   dotfiles
   dotfiles_new_student
   dotfiles_new_laptop
@@ -63,11 +62,9 @@ WINDOWS = %w[
   setup/windows_terminal
   vscode_extensions
   setup/vscode_liveshare
-  setup/git
-  setup/zsh
+  setup/cli_tools
   setup/oh_my_zsh
   setup/gh_cli
-  setup/ssh_key
   ubuntu_gcloud
   dotfiles
   dotfiles_new_student
@@ -106,12 +103,10 @@ LINUX = %w[
   setup/ubuntu_vscode
   vscode_extensions
   setup/vscode_liveshare
-  setup/git
+  setup/cli_tools
   chrome
-  setup/zsh
   setup/oh_my_zsh
   setup/gh_cli
-  setup/ssh_key
   ubuntu_gcloud
   dotfiles
   dotfiles_new_student
@@ -165,7 +160,7 @@ def load_partial(partial, locale)
   file = File.join("_partials", "#{partial}.md")
   if match_data
     require 'open-uri'
-    content = URI.open(File.join("https://raw.githubusercontent.com/lewagon/setup/master", file))
+    content = URI.open(File.join("https://raw.githubusercontent.com/lewagon/setup/22q4-setup-bug-bash", file))
             .string
     # replace data-setup repo relative path by setup repo URL
     image_paths = content.scan(/\!\[.*\]\((.*)\)/).flatten

--- a/macOS.md
+++ b/macOS.md
@@ -55,7 +55,7 @@ Open a new terminal window from Applications > Utilities or search for it with [
 
 ![Open Terminal on macOS](https://github.com/lewagon/setup/blob/master/images/macos_open_terminal.png)
 
-Copy-paste the following command in the terminal and hit `ENTER` to execute.
+Copy-paste the following command in the terminal and hit `Enter` to execute.
 
 ``` bash
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/lewagon/setup/master/utils/macos_list_processor_type.sh)"
@@ -105,7 +105,7 @@ During this setup you will be asked to **quit and re-open** applications multipl
 
 ## Command Line Tools
 
-Open a new terminal, copy-paste the following command and hit `ENTER`:
+Open a new terminal, copy-paste the following command and hit `Enter`:
 
 ```bash
 xcode-select --install
@@ -270,7 +270,7 @@ Here is a list of the extensions you are installing:
 
 [Visual Studio Live Share](https://visualstudio.microsoft.com/services/live-share/) is a VS Code extension which allows you to share the code in your text editor for debugging and pair-programming: let's set it up!
 
-Launch VS Code from your terminal by typing `code` and pressing `ENTER`.
+Launch VS Code from your terminal by typing `code` and pressing `Enter`.
 
 Click on the little arrow at the bottom of the left bar :point_down:
 
@@ -1091,7 +1091,7 @@ The idea is that you'll have Slack open all day, so that you can share useful li
 
 To ensure that everything is working fine for video calls, let's test your camera and microphone:
 - Open the Slack app
-- In any channel message bar type `/call --test` and press `ENTER`
+- In any channel message bar type `/call --test` and press `Enter`
 - Click on the "Start test" green button
 
 ![Check microphone and webcam with Slack](https://github.com/lewagon/setup/blob/master/images/slack_call_test.png)

--- a/macOS.md
+++ b/macOS.md
@@ -321,18 +321,30 @@ First in order to **login**, copy-paste the following command in your terminal:
 gh auth login -s 'user:email' -w
 ```
 
-You will get the following output:
+gh will ask you few questions:
+
+`What is your preferred protocol for Git operations?` With the arrows, choose `SSH` and press `Enter`. SSH is a protocol to log in using SSH keys instead of the well known username/password pair.
+
+`Generate a new SSH key to add to your GitHub account?` Press `Enter` to ask gh to generate the SSH keys for you.
+
+If you already have SSH keys, you will see instead `Upload your SSH public key to your GitHub account?` With the arrows, select your public key file path and press `Enter`.
+
+`Enter a passphrase for your new SSH key (Optional)`. Type something you want and that you'll remember. It's a password to protect your private key stored on your hard drive. Then press `Enter`.
+
+:warning: When you type your passphrase, nothing will show up on the screen, **that's normal**. This is a security feature to mask not only your passphrase as a whole but also its length. Just type your passphrase and when you're done, press `Enter`.
+
+You will then get the following output:
 
 ```bash
 ! First copy your one-time code: 0EF9-D015
 - Press Enter to open github.com in your browser...
 ```
 
-Select and copy the code (`0EF9-D015` in the example), then press `ENTER`.
+Select and copy the code (`0EF9-D015` in the example), then press `Enter`.
 
 Your browser will open and ask you to authorize GitHub CLI to use your GitHub account. Accept and wait a bit.
 
-Come back to the terminal, press `ENTER` again, and that's it.
+Come back to the terminal, press `Enter` again, and that's it.
 
 To check that you are properly connected, type:
 
@@ -343,53 +355,6 @@ gh auth status
 :heavy_check_mark: If you get `Logged in to github.com as <YOUR USERNAME> `, then all good :+1:
 
 :x: If not, **contact a teacher**.
-
-Then run the following configuration line:
-
-```bash
-gh config set git_protocol ssh
-```
-
-
-## SSH Key
-
-### Generation
-
-We need to generate SSH keys which are going to be used by GitHub to authenticate you. You can think of it as a way to log in, but different from the well known username/password pair.
-
-:warning: If you already generated keys that you already use with other services, you can skip this step.
-
-Open a terminal and copy-paste this command, replacing the email with **yours** (the same one you used to create your GitHub account).
-
-```bash
-mkdir -p ~/.ssh && ssh-keygen -t ed25519 -o -a 100 -f ~/.ssh/id_ed25519 -C "TYPE_YOUR_EMAIL@HERE.com"
-```
-
-It will prompt for information. Just press enter until it asks for a **passphrase**.
-
-:warning: When asked for a passphrase, put something you want and that you'll remember. It's a password to protect your private key stored on your hard drive.
-
-:warning: When you type your passphrase, nothing will show up on the screen, **that's normal**. This is a security feature to mask not only your passphrase as a whole but also its length. Just type your passphrase and when you're done, press `ENTER`.
-
-### Giving your public key to GitHub
-
-Now, you will give your **public** key to GitHub.
-
-In your terminal copy-paste the following command:
-
-```bash
-gh auth refresh -s write:public_key
-```
-
-It will prompt a one time code (####-####) on the screen. Copy it and press `ENTER`, then paste the code in your browser and follow the instructions to **Authorize GitHub**.
-
-Back in the terminal, press `ENTER` and run this:
-
-```bash
-gh ssh-key add ~/.ssh/id_ed25519.pub
-```
-
-This should return `✓ Public key added to your account`. If not, do not hesitate to **contact a teacher**.
 
 
 ## Dotfiles


### PR DESCRIPTION
In the [22q4 web setup bug bash PR](https://github.com/lewagon/setup/pull/369), we update some partials which are used it the data setup, as you can see [here](https://github.com/lewagon/setup/pull/369/files#diff-8ce4c4af01166c2b6458748fdec5aa50a217aec720d14f28e0f3f002c095ab97):
- the `ssh_key` partial is removed and its content is updated and merged into the `gh_cli` partial
- the `git` and `zsh` partials are merged into one single `cli_tools` partials

The present PR implement the corresponding changes in the data setup build script. 

## TODO before merge
- [x] Wait for https://github.com/lewagon/setup/pull/369 to be merged
- [x] Restore the branch name to `master` in the partial URL [here](https://github.com/lewagon/data-setup/pull/205/files#diff-8ce4c4af01166c2b6458748fdec5aa50a217aec720d14f28e0f3f002c095ab97R163)