### PR TITLE
Moved GCP credentials from `~/.aliases` to `~/.zshrc`

### DIFF
--- a/_partials/gcp_setup_mid.md
+++ b/_partials/gcp_setup_mid.md
@@ -7,5 +7,5 @@
 - Store the **absolute path** to the `JSON` file as an environment variable:
 
 ``` bash
-echo 'export GOOGLE_APPLICATION_CREDENTIALS=/path/to/the/SERVICE_ACCOUNT_JSON_FILE_CONTAINING_YOUR_SECRET_KEY.json' >> ~/.aliases
+echo 'export GOOGLE_APPLICATION_CREDENTIALS=/path/to/the/SERVICE_ACCOUNT_JSON_FILE_CONTAINING_YOUR_SECRET_KEY.json' >> ~/.zshrc
 ```

--- a/_partials/gcp_setup_mid.md
+++ b/_partials/gcp_setup_mid.md
@@ -9,3 +9,12 @@
 ``` bash
 echo 'export GOOGLE_APPLICATION_CREDENTIALS=/path/to/the/SERVICE_ACCOUNT_JSON_FILE_CONTAINING_YOUR_SECRET_KEY.json' >> ~/.zshrc
 ```
+**Note:** every time you run this command, it will add this line to your zshrc file regardless of whether you already have it. If you made a mistake and need to fix it, preferably open the file and edit the line!
+
+You can do so by running
+
+```bash
+code ~/.zshrc
+```
+
+in the Terminal! 😄

--- a/macOS.md
+++ b/macOS.md
@@ -994,8 +994,17 @@ The browser has now saved the service account json file 🔑 in your downloads d
 - Store the **absolute path** to the `JSON` file as an environment variable:
 
 ``` bash
-echo 'export GOOGLE_APPLICATION_CREDENTIALS=/path/to/the/SERVICE_ACCOUNT_JSON_FILE_CONTAINING_YOUR_SECRET_KEY.json' >> ~/.aliases
+echo 'export GOOGLE_APPLICATION_CREDENTIALS=/path/to/the/SERVICE_ACCOUNT_JSON_FILE_CONTAINING_YOUR_SECRET_KEY.json' >> ~/.zshrc
 ```
+**Note:** every time you run this command, it will add this line to your zshrc file regardless of whether you already have it. If you made a mistake and need to fix it, preferably open the file and edit the line!
+
+You can do so by running
+
+```bash
+code ~/.zshrc
+```
+
+in the Terminal! 😄
 
 
 


### PR DESCRIPTION
Fixes #212

I have moved the GCP credentials from `~/.aliases` to `~/.zshrc`.

Furthermore, I've added a note to advise the student to edit the line inside the `.zshrc` file if mistakes need to be fixed, rather than re-adding the corrected version of the line. This is because when debugging credentials issues, I often see students with 10+ different versions of this line inside of `.aliases`, which usually just confuses them.