### PR TITLE
Added Graphviz to requirements (Ensemble Methods)

### DIFF
--- a/LINUX.es.md
+++ b/LINUX.es.md
@@ -139,6 +139,9 @@ Vamos a instalarlos, junto con otros programas útiles:
 
 ```bash
 sudo apt update
+```
+
+```bash
 sudo apt install -y curl git imagemagick jq unzip vim zsh
 ```
 
@@ -153,6 +156,7 @@ Instalemos la [CLI oficial de GitHub](https://cli.github.com) (Interfaz de Líne
 En tu terminal, copia y pega los siguientes comandos y escribe tu contraseña si te la piden:
 
 ```bash
+sudo apt remove -y gitsome # gh command can conflict with gitsome if already installed
 curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
 echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
 sudo apt update

--- a/LINUX.md
+++ b/LINUX.md
@@ -139,6 +139,9 @@ Let's install them, along with other useful tools:
 
 ```bash
 sudo apt update
+```
+
+```bash
 sudo apt install -y curl git imagemagick jq unzip vim zsh
 ```
 
@@ -153,6 +156,7 @@ Let's now install [GitHub official CLI](https://cli.github.com) (Command Line In
 In your terminal, copy-paste the following commands and type in your password if asked:
 
 ```bash
+sudo apt remove -y gitsome # gh command can conflict with gitsome if already installed
 curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
 echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
 sudo apt update

--- a/WINDOWS.es.md
+++ b/WINDOWS.es.md
@@ -568,6 +568,9 @@ Vamos a instalarlos, junto con otros programas útiles:
 
 ```bash
 sudo apt update
+```
+
+```bash
 sudo apt install -y curl git imagemagick jq unzip vim zsh
 ```
 
@@ -582,6 +585,7 @@ Instalemos la [CLI oficial de GitHub](https://cli.github.com) (Interfaz de Líne
 En tu terminal, copia y pega los siguientes comandos y escribe tu contraseña si te la piden:
 
 ```bash
+sudo apt remove -y gitsome # gh command can conflict with gitsome if already installed
 curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
 echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
 sudo apt update

--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -568,6 +568,9 @@ Let's install them, along with other useful tools:
 
 ```bash
 sudo apt update
+```
+
+```bash
 sudo apt install -y curl git imagemagick jq unzip vim zsh
 ```
 
@@ -582,6 +585,7 @@ Let's now install [GitHub official CLI](https://cli.github.com) (Command Line In
 In your terminal, copy-paste the following commands and type in your password if asked:
 
 ```bash
+sudo apt remove -y gitsome # gh command can conflict with gitsome if already installed
 curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
 echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
 sudo apt update

--- a/specs/base/package_platforms.md
+++ b/specs/base/package_platforms.md
@@ -72,6 +72,7 @@ py3-none-any                                tensorflow-datasets
 py3-none-any                                ipython
 py3-none-any                                jupyter
 py3-none-any                                google-cloud-bigquery
+py3-none-any                                graphviz
 py3-none-any                                Flask
 py3-none-any                                Flask-Cors
 py3-none-any                                mlflow

--- a/specs/base/packages.yml
+++ b/specs/base/packages.yml
@@ -66,6 +66,8 @@ modules:
     - tensorflow-datasets
     - gensim
     - kaggle
+  07-ML-Ops:
+    - graphviz
   07-Data-Engineering:
     - ipython
     - jupyter

--- a/specs/constraintless/apple_intel.txt
+++ b/specs/constraintless/apple_intel.txt
@@ -66,3 +66,4 @@ black
 pydantic
 nbdime
 tensorflow
+graphviz

--- a/specs/constraintless/apple_silicon.txt
+++ b/specs/constraintless/apple_silicon.txt
@@ -66,3 +66,4 @@ black
 pydantic
 nbdime
 tensorflow-macos
+graphviz

--- a/specs/constraintless/linux.txt
+++ b/specs/constraintless/linux.txt
@@ -66,3 +66,4 @@ black
 pydantic
 nbdime
 tensorflow
+graphviz

--- a/specs/generated/apple_intel.txt
+++ b/specs/generated/apple_intel.txt
@@ -66,3 +66,4 @@ black
 pydantic
 nbdime
 tensorflow
+graphviz

--- a/specs/generated/apple_silicon.txt
+++ b/specs/generated/apple_silicon.txt
@@ -66,3 +66,4 @@ black
 pydantic
 nbdime
 tensorflow-macos<2.6
+graphviz

--- a/specs/generated/linux.txt
+++ b/specs/generated/linux.txt
@@ -66,3 +66,4 @@ black
 pydantic
 nbdime
 tensorflow
+graphviz

--- a/specs/releases/apple_intel.txt
+++ b/specs/releases/apple_intel.txt
@@ -69,6 +69,7 @@ google-pasta==0.2.0
 google-resumable-media==2.1.0
 google-trans-new==1.1.9
 googleapis-common-protos==1.54.0
+graphviz==0.20
 greenlet==1.1.2
 grpcio==1.43.0
 grpcio-status==1.43.0

--- a/specs/releases/apple_silicon.txt
+++ b/specs/releases/apple_silicon.txt
@@ -74,6 +74,7 @@ google-pasta==0.2.0
 google-resumable-media==1.3.3
 google-trans-new==1.1.9
 googleapis-common-protos==1.54.0
+graphviz==0.20
 greenlet==1.1.2
 grpcio==1.34.1
 gunicorn==20.1.0

--- a/specs/releases/linux.txt
+++ b/specs/releases/linux.txt
@@ -65,6 +65,7 @@ google-pasta==0.2.0
 google-resumable-media==2.1.0
 google-trans-new==1.1.9
 googleapis-common-protos==1.54.0
+graphviz==0.20
 greenlet==1.1.2
 grpcio==1.43.0
 grpcio-status==1.43.0


### PR DESCRIPTION
Reference https://github.com/lewagon/teachers/issues/660

As mentioned by Freddy in point 6, there is no reason we should exclude Graphviz from our requirements, since it has no dependencies that aren't already fulfilled, and it works with Apple Silicon.

This package is used in the [Ensemble Method lecture](https://kitt.lewagon.com/camps/943/lectures/content/05-ML_07-Ensemble-Methods.slides.html?title=Ensemble+Methods#/1/3) to generate a graphical representation of the decision tree used throughout the lecture. The code to generate it is already in the lecture anyway, so by adding the package we ensure that they can run it themselves.