### PR TITLE
remove python-dev package not available on latest ubuntu images

### DIFF
--- a/LINUX.es.md
+++ b/LINUX.es.md
@@ -450,7 +450,7 @@ Instala algunas [dependencias](https://github.com/pyenv/pyenv/wiki/common-build-
 sudo apt-get update; sudo apt-get install make build-essential libssl-dev zlib1g-dev \
 libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \
 libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev \
-python-dev python3-dev
+python3-dev
 ```
 
 Instala la [última versión estable de Python](https://www.python.org/doc/versions/) que sea aceptada en el currículum de Le Wagon:

--- a/LINUX.md
+++ b/LINUX.md
@@ -457,7 +457,7 @@ Let's install some [dependencies](https://github.com/pyenv/pyenv/wiki/common-bui
 sudo apt-get update; sudo apt-get install make build-essential libssl-dev zlib1g-dev \
 libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \
 libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev \
-python-dev python3-dev
+python3-dev
 ```
 
 Let's install the [latest stable version of Python](https://www.python.org/doc/versions/) supported by Le Wagon's curriculum:

--- a/WINDOWS.es.md
+++ b/WINDOWS.es.md
@@ -868,7 +868,7 @@ Instala algunas [dependencias](https://github.com/pyenv/pyenv/wiki/common-build-
 sudo apt-get update; sudo apt-get install make build-essential libssl-dev zlib1g-dev \
 libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \
 libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev \
-python-dev python3-dev
+python3-dev
 ```
 
 Instala la [última versión estable de Python](https://www.python.org/doc/versions/) que sea aceptada en el currículum de Le Wagon:

--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -875,7 +875,7 @@ Let's install some [dependencies](https://github.com/pyenv/pyenv/wiki/common-bui
 sudo apt-get update; sudo apt-get install make build-essential libssl-dev zlib1g-dev \
 libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \
 libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev \
-python-dev python3-dev
+python3-dev
 ```
 
 Let's install the [latest stable version of Python](https://www.python.org/doc/versions/) supported by Le Wagon's curriculum:

--- a/_partials/es/ubuntu_python.md
+++ b/_partials/es/ubuntu_python.md
@@ -17,7 +17,7 @@ Instala algunas [dependencias](https://github.com/pyenv/pyenv/wiki/common-build-
 sudo apt-get update; sudo apt-get install make build-essential libssl-dev zlib1g-dev \
 libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \
 libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev \
-python-dev python3-dev
+python3-dev
 ```
 
 Instala la [última versión estable de Python](https://www.python.org/doc/versions/) que sea aceptada en el currículum de Le Wagon:

--- a/_partials/ubuntu_python.md
+++ b/_partials/ubuntu_python.md
@@ -17,7 +17,7 @@ Let's install some [dependencies](https://github.com/pyenv/pyenv/wiki/common-bui
 sudo apt-get update; sudo apt-get install make build-essential libssl-dev zlib1g-dev \
 libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \
 libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev \
-python-dev python3-dev
+python3-dev
 ```
 
 Let's install the [latest stable version of Python](https://www.python.org/doc/versions/) supported by Le Wagon's curriculum:


### PR DESCRIPTION
fixes https://github.com/lewagon/data-setup/issues/219

I have tested on a GCE Ubuntu LTS VM, but not on a Linux or WSL machine