### PR TITLE
Windows Jupyter - clarified commenting out the c.NotebookApp.use_redirect_file line

### DIFF
--- a/WINDOWS.es.md
+++ b/WINDOWS.es.md
@@ -1046,7 +1046,7 @@ Localiza la siguiente línea en el archivo de configuración:
 # c.NotebookApp.use_redirect_file = True
 ```
 
-Y reemplázala por esta:
+Y reemplázala por éste **precisamente** 👇 (incluyendo la eliminación del símbolo `#`)
 
 ``` python
 c.NotebookApp.use_redirect_file = False

--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -1055,7 +1055,7 @@ Locate the following line in the configuration file:
 # c.NotebookApp.use_redirect_file = True
 ```
 
-And replace it with this one:
+And replace it with this one **precisely** 👇 (including removing the `#` symbol)
 
 ``` python
 c.NotebookApp.use_redirect_file = False

--- a/_partials/es/win_jupyter.md
+++ b/_partials/es/win_jupyter.md
@@ -21,7 +21,7 @@ Localiza la siguiente línea en el archivo de configuración:
 # c.NotebookApp.use_redirect_file = True
 ```
 
-Y reemplázala por esta:
+Y reemplázala por éste **precisamente** 👇 (incluyendo la eliminación del símbolo `#`)
 
 ``` python
 c.NotebookApp.use_redirect_file = False

--- a/_partials/win_jupyter.md
+++ b/_partials/win_jupyter.md
@@ -21,7 +21,7 @@ Locate the following line in the configuration file:
 # c.NotebookApp.use_redirect_file = True
 ```
 
-And replace it with this one:
+And replace it with this one **precisely** 👇 (including removing the `#` symbol)
 
 ``` python
 c.NotebookApp.use_redirect_file = False


### PR DESCRIPTION
As there are many batches starting next week, proposing a quick fix for the issue raised by [teachers-data on Slack](https://lewagon-alumni.slack.com/archives/C015E0C601F/p1665147245366119).

### Change

* Mentioned "removing the `#` symbol" in the instruction about updating `c.NotebookApp.use_redirect_file` jupyter config