### PR TITLE
Check m1 only on macOS devices

### DIFF
--- a/checks/pip_check.sh
+++ b/checks/pip_check.sh
@@ -6,12 +6,15 @@ while read -r line; do
 done <<< "$PACKAGES"
 missing=()
 arch_name="$(uname -m)"
-if [ "${arch_name}" = "x86_64" ]; then
-  if [ "$(sysctl -in sysctl.proc_translated)" = "1" ]; then
+if [[ $OSTYPE == 'darwin'* ]]
+then
+  if [ "${arch_name}" = "x86_64" ]; then
+    if [ "$(sysctl -in sysctl.proc_translated)" = "1" ]; then
+      arch_name='m1'
+    fi
+  elif [ "${arch_name}" = "arm64" ]; then
     arch_name='m1'
   fi
-elif [ "${arch_name}" = "arm64" ]; then
-  arch_name='m1'
 fi
 if [ $arch_name = 'm1' ]; then
   REQUIRED=('pytest' 'pylint' 'ipdb' 'PyYAML' 'nbresult' 'autopep8' 'flake8' 'yapf' 'lxml' 'requests' 'beautifulsoup4' 'jupyterlab' 'pandas' 'matplotlib' 'seaborn' 'plotly' 'scikit-learn' 'tensorflow-macos' 'nbconvert' 'xgboost' 'statsmodels' 'pandas-profiling' 'jupyter-resource-usage')


### PR DESCRIPTION
This check script is used for windows and linux as well. On these systems running ``sysctl -in sysctl.proc_translated`` can result in ``sysctl: invalid option -- 'i'``

Either way checking for m1 should only happen on macOS anyways.