### PR TITLE
Remove pandas profiling from checks

### DIFF
--- a/WINDOWS.es.md
+++ b/WINDOWS.es.md
@@ -392,6 +392,20 @@ Si la salida no contiene `LANG=en_US.UTF-8`, ejecute el siguiente comando en un 
 sudo locale-gen en_US.UTF-8
 ```
 
+Si después, recibes una advertencia (`bash: warning: setlocale: LC_ALL: cannot change locale (en_US.utf-8)`) en tu terminal, por favor haz lo siguiente:
+
+<details>
+  <summary>Generar la configuración regional<>/summary>
+
+Por favor, ejecuta estas líneas en tu terminal.
+
+```bash
+sudo update-locale LANG=en_US.UTF8
+sudo apt-get install language-pack-en language-pack-en-base manpages
+exec zsh
+```
+</details>
+
 Ya puedes cerrar la ventana de la terminal.
 
 

--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -380,7 +380,7 @@ wsl -l -v
 
 The locale is a mechanism allowing to customize programs to your language and country.
 
-Let's verify that the default locale is set to english, please type this in the Ubuntu terminal:
+Let's verify that the default locale is set to English, please type this in the Ubuntu terminal:
 
 ```bash
 locale
@@ -391,6 +391,20 @@ If the output does not contain `LANG=en_US.UTF-8`, run the following command in 
 ```bash
 sudo locale-gen en_US.UTF-8
 ```
+
+If after, you receive a warning (`bash: warning: setlocale: LC_ALL: cannot change locale (en_US.utf-8)`) in your terminal, please do the following:
+
+<details>
+  <summary>Generate locale</summary>
+
+Please, run this lines in your terminal.
+
+```bash
+sudo update-locale LANG=en_US.UTF8
+sudo apt-get install language-pack-en language-pack-en-base manpages
+exec zsh
+```
+</details>
 
 You can now close this terminal window.
 

--- a/checks/pip_check.sh
+++ b/checks/pip_check.sh
@@ -1,4 +1,4 @@
-REQUIRED=('pytest' 'pylint' 'ipdb' 'PyYAML' 'nbresult' 'autopep8' 'flake8' 'yapf' 'lxml' 'requests' 'beautifulsoup4' 'jupyterlab' 'pandas' 'matplotlib' 'seaborn' 'plotly' 'scikit-learn' 'tensorflow' 'nbconvert' 'xgboost' 'statsmodels' 'pandas-profiling' 'jupyter-resource-usage')
+REQUIRED=('pytest' 'pylint' 'ipdb' 'PyYAML' 'nbresult' 'autopep8' 'flake8' 'yapf' 'lxml' 'requests' 'beautifulsoup4' 'jupyterlab' 'pandas' 'matplotlib' 'seaborn' 'plotly' 'scikit-learn' 'tensorflow' 'nbconvert' 'xgboost' 'statsmodels' 'jupyter-resource-usage')
 PACKAGES=$(pip freeze)
 PACKS=()
 while read -r line; do
@@ -14,7 +14,7 @@ elif [ "${arch_name}" = "arm64" ]; then
   arch_name='m1'
 fi
 if [ $arch_name = 'm1' ]; then
-  REQUIRED=('pytest' 'pylint' 'ipdb' 'PyYAML' 'nbresult' 'autopep8' 'flake8' 'yapf' 'lxml' 'requests' 'beautifulsoup4' 'jupyterlab' 'pandas' 'matplotlib' 'seaborn' 'plotly' 'scikit-learn' 'tensorflow-macos' 'nbconvert' 'xgboost' 'statsmodels' 'pandas-profiling' 'jupyter-resource-usage')
+  REQUIRED=('pytest' 'pylint' 'ipdb' 'PyYAML' 'nbresult' 'autopep8' 'flake8' 'yapf' 'lxml' 'requests' 'beautifulsoup4' 'jupyterlab' 'pandas' 'matplotlib' 'seaborn' 'plotly' 'scikit-learn' 'tensorflow-macos' 'nbconvert' 'xgboost' 'statsmodels' 'jupyter-resource-usage')
 fi
 for r in ${REQUIRED[@]}; do
   echo $r


### PR DESCRIPTION
Reasons:
- Pandas-profling has been remamed ydata-profiling
- We removed it in https://github.com/lewagon/data-setup/pull/272 from the Apple Silicon requirements, because of incompatibility with scipy

It is a non-essential package anyway, and is used in only one challenge (04-01-03 Exploratory Analysis), which includes instructions to pip install it.

Other changes are auto-generated by the build, following an addition to the web dev setup. Good to include in DS too.