### PR TITLE
Removing pandas-profiling from post-setup checks

### DIFF
--- a/WINDOWS.es.md
+++ b/WINDOWS.es.md
@@ -401,8 +401,8 @@ Por favor, ejecuta estas líneas en tu terminal.
 
 ```bash
 sudo update-locale LANG=en_US.UTF8
+sudo apt-get update
 sudo apt-get install language-pack-en language-pack-en-base manpages
-exec zsh
 ```
 </details>
 

--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -401,8 +401,8 @@ Please, run this lines in your terminal.
 
 ```bash
 sudo update-locale LANG=en_US.UTF8
+sudo apt-get update
 sudo apt-get install language-pack-en language-pack-en-base manpages
-exec zsh
 ```
 </details>
 

--- a/checks/pip_check.sh
+++ b/checks/pip_check.sh
@@ -1,4 +1,4 @@
-REQUIRED=('pytest' 'pylint' 'ipdb' 'PyYAML' 'nbresult' 'autopep8' 'flake8' 'yapf' 'lxml' 'requests' 'beautifulsoup4' 'jupyterlab' 'pandas' 'matplotlib' 'seaborn' 'plotly' 'scikit-learn' 'tensorflow' 'nbconvert' 'xgboost' 'statsmodels' 'pandas-profiling' 'jupyter-resource-usage')
+REQUIRED=('pytest' 'pylint' 'ipdb' 'PyYAML' 'nbresult' 'autopep8' 'flake8' 'yapf' 'lxml' 'requests' 'beautifulsoup4' 'jupyterlab' 'pandas' 'matplotlib' 'seaborn' 'plotly' 'scikit-learn' 'tensorflow' 'nbconvert' 'xgboost' 'statsmodels' 'jupyter-resource-usage')
 PACKAGES=$(pip freeze)
 PACKS=()
 while read -r line; do
@@ -14,7 +14,7 @@ elif [ "${arch_name}" = "arm64" ]; then
   arch_name='m1'
 fi
 if [ $arch_name = 'm1' ]; then
-  REQUIRED=('pytest' 'pylint' 'ipdb' 'PyYAML' 'nbresult' 'autopep8' 'flake8' 'yapf' 'lxml' 'requests' 'beautifulsoup4' 'jupyterlab' 'pandas' 'matplotlib' 'seaborn' 'plotly' 'scikit-learn' 'tensorflow-macos' 'nbconvert' 'xgboost' 'statsmodels' 'pandas-profiling' 'jupyter-resource-usage')
+  REQUIRED=('pytest' 'pylint' 'ipdb' 'PyYAML' 'nbresult' 'autopep8' 'flake8' 'yapf' 'lxml' 'requests' 'beautifulsoup4' 'jupyterlab' 'pandas' 'matplotlib' 'seaborn' 'plotly' 'scikit-learn' 'tensorflow-macos' 'nbconvert' 'xgboost' 'statsmodels' 'jupyter-resource-usage')
 fi
 for r in ${REQUIRED[@]}; do
   echo $r


### PR DESCRIPTION
Reasons:

- Pandas-profiling has been remamed ydata-profiling.
- We removed it in Update apple_silicon.txt #272 from the Apple Silicon requirements, because of incompatibility with scipy
- It is a non-essential package anyway, and is used in only one challenge (04-01-03 Exploratory Analysis), which includes instructions to pip install it.