### PR TITLE
Bump grpcio to 1.62.1 for Apple silicon

### DIFF
--- a/specs/releases/apple_silicon.txt
+++ b/specs/releases/apple_silicon.txt
@@ -62,7 +62,7 @@ google-pasta==0.2.0
 google-resumable-media==2.4.0
 google-trans-new==1.1.9
 googleapis-common-protos==1.56.4
-grpcio==1.50.0
+grpcio==1.62.1
 grpcio-status==1.48.2
 gunicorn==21.2.0
 h11==0.12.0


### PR DESCRIPTION
Fixes lewagon/teachers/issues/2164
Recurring setup problem on macos failing to build grpcio because wheel for 1.50.0 is not available on pypi.

Bumping to more recent version solves this.

Following packages depend on it:
- google-cloud-bigquery (but only used in taxifare, separate env)
- pandas-gbq (only used in one lecture, tested with new version: ok)
- tensorflow-macos:
  - tested on CNN (challenge 1 mnist): OK
  - tested on RNN (weather): OK
  - in taxifare we don't fix the grpcio version so it uses most recent version and all works fine, so changing

Concluding: safe to bump this version after test on mac m1.