### PR TITLE
Update GCP link to enable services

### DIFF
--- a/LINUX.es.md
+++ b/LINUX.es.md
@@ -46,6 +46,8 @@ Ya puedes cerrar la aplicación Zoom.
 
 ![Foto GitHub](https://github.com/lewagon/setup/blob/master/images/github_picture.png)
 
+:point_right: **[Habilita la Autenticación de Dos Factores (2FA)](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication#configuring-two-factor-authentication-using-text-messages)**. GitHub te enviará mensajes de texto con un código cuando intentes iniciar sesión. Esto es importante para la seguridad y también pronto será necesario para contribuir código en GitHub.
+
 
 ## Visual Studio Code
 

--- a/LINUX.es.md
+++ b/LINUX.es.md
@@ -838,7 +838,7 @@ Cuando la cuenta sea validada recibirás un email diciendo lo siguiente: "Your G
 
 ℹ️ Tienes un **crédito de $300** para usar con recursos de Google Cloud. Esto será más que suficiente para el bootcamp.
 
-- [Habilita las APIs AI Platform Training & Prediction y Compute Engine APIs](https://console.cloud.google.com/flows/enableapi?apiid=ml.googleapis.com,compute_component&_ga=2.269215094.662509797.1580849510-2071889129.1567861089&_gac=1.154971594.1580849512.CjwKCAiAyeTxBRBvEiwAuM8dnbZ6uMwizbZW44J2mBCX6ncEjwjwpgF8S8QsvhYAXLkJ8awDnIRTNRoCJ_0QAvD_BwE) (Esto puede tomar varios minutos)
+- [Habilita las APIs BigQuery y Compute Engine](https://console.cloud.google.com/flows/enableapi?apiid=bigquery,compute) (Esto puede tomar varios minutos)
 
 ### Configuración de Cloud sdk
 

--- a/LINUX.md
+++ b/LINUX.md
@@ -46,6 +46,8 @@ Have you signed up to GitHub? If not, [do it right away](https://github.com/join
 
 ![GitHub picture](https://github.com/lewagon/setup/blob/master/images/github_picture.png)
 
+:point_right: **[Enable Two-Factor Authentication (2FA)](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication#configuring-two-factor-authentication-using-text-messages)**. GitHub will send you text messages with a code when you try to log in. This is important for security and also will soon be required in order to contribute code on GitHub.
+
 
 ## Visual Studio Code
 
@@ -859,7 +861,7 @@ Once the verification goes through, you should receive an email stating that "Yo
 
 ℹ️ You have a **$300 credit** to use for Google Cloud resources, which will be more than enough for the bootcamp.
 
-- [Enable the AI Platform Training & Prediction and Compute Engine APIs](https://console.cloud.google.com/flows/enableapi?apiid=ml.googleapis.com,compute_component&_ga=2.269215094.662509797.1580849510-2071889129.1567861089&_gac=1.154971594.1580849512.CjwKCAiAyeTxBRBvEiwAuM8dnbZ6uMwizbZW44J2mBCX6ncEjwjwpgF8S8QsvhYAXLkJ8awDnIRTNRoCJ_0QAvD_BwE) (This step may take a few minutes)
+- [Enable the BigQuery and Compute Engine APIs](https://console.cloud.google.com/flows/enableapi?apiid=bigquery,compute) (This step may take a few minutes)
 
 ### Configure Cloud sdk
 

--- a/VM.es.md
+++ b/VM.es.md
@@ -57,6 +57,8 @@ Lo recomendamos como navegador predeterminado porque es el más compatible con l
 
 ![Foto GitHub](https://github.com/lewagon/setup/blob/master/images/github_picture.png)
 
+:point_right: **[Habilita la Autenticación de Dos Factores (2FA)](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication#configuring-two-factor-authentication-using-text-messages)**. GitHub te enviará mensajes de texto con un código cuando intentes iniciar sesión. Esto es importante para la seguridad y también pronto será necesario para contribuir código en GitHub.
+
 
 
 

--- a/VM.md
+++ b/VM.md
@@ -57,6 +57,8 @@ Have you signed up to GitHub? If not, [do it right away](https://github.com/join
 
 ![GitHub picture](https://github.com/lewagon/setup/blob/master/images/github_picture.png)
 
+:point_right: **[Enable Two-Factor Authentication (2FA)](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication#configuring-two-factor-authentication-using-text-messages)**. GitHub will send you text messages with a code when you try to log in. This is important for security and also will soon be required in order to contribute code on GitHub.
+
 
 ## SSH key
 

--- a/WINDOWS.es.md
+++ b/WINDOWS.es.md
@@ -1471,7 +1471,7 @@ Cuando la cuenta sea validada recibirás un email diciendo lo siguiente: "Your G
 
 ℹ️ Tienes un **crédito de $300** para usar con recursos de Google Cloud. Esto será más que suficiente para el bootcamp.
 
-- [Habilita las APIs AI Platform Training & Prediction y Compute Engine APIs](https://console.cloud.google.com/flows/enableapi?apiid=ml.googleapis.com,compute_component&_ga=2.269215094.662509797.1580849510-2071889129.1567861089&_gac=1.154971594.1580849512.CjwKCAiAyeTxBRBvEiwAuM8dnbZ6uMwizbZW44J2mBCX6ncEjwjwpgF8S8QsvhYAXLkJ8awDnIRTNRoCJ_0QAvD_BwE) (Esto puede tomar varios minutos)
+- [Habilita las APIs BigQuery y Compute Engine](https://console.cloud.google.com/flows/enableapi?apiid=bigquery,compute) (Esto puede tomar varios minutos)
 
 ### Configuración de Cloud sdk
 

--- a/WINDOWS.es.md
+++ b/WINDOWS.es.md
@@ -46,6 +46,8 @@ Ya puedes cerrar la aplicación Zoom.
 
 ![Foto GitHub](https://github.com/lewagon/setup/blob/master/images/github_picture.png)
 
+:point_right: **[Habilita la Autenticación de Dos Factores (2FA)](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication#configuring-two-factor-authentication-using-text-messages)**. GitHub te enviará mensajes de texto con un código cuando intentes iniciar sesión. Esto es importante para la seguridad y también pronto será necesario para contribuir código en GitHub.
+
 
 ## La versión de Windows
 

--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -46,6 +46,8 @@ Have you signed up to GitHub? If not, [do it right away](https://github.com/join
 
 ![GitHub picture](https://github.com/lewagon/setup/blob/master/images/github_picture.png)
 
+:point_right: **[Enable Two-Factor Authentication (2FA)](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication#configuring-two-factor-authentication-using-text-messages)**. GitHub will send you text messages with a code when you try to log in. This is important for security and also will soon be required in order to contribute code on GitHub.
+
 
 ## Windows version
 
@@ -1511,7 +1513,7 @@ Once the verification goes through, you should receive an email stating that "Yo
 
 ℹ️ You have a **$300 credit** to use for Google Cloud resources, which will be more than enough for the bootcamp.
 
-- [Enable the AI Platform Training & Prediction and Compute Engine APIs](https://console.cloud.google.com/flows/enableapi?apiid=ml.googleapis.com,compute_component&_ga=2.269215094.662509797.1580849510-2071889129.1567861089&_gac=1.154971594.1580849512.CjwKCAiAyeTxBRBvEiwAuM8dnbZ6uMwizbZW44J2mBCX6ncEjwjwpgF8S8QsvhYAXLkJ8awDnIRTNRoCJ_0QAvD_BwE) (This step may take a few minutes)
+- [Enable the BigQuery and Compute Engine APIs](https://console.cloud.google.com/flows/enableapi?apiid=bigquery,compute) (This step may take a few minutes)
 
 ### Configure Cloud sdk
 

--- a/_partials/es/gcp_setup.md
+++ b/_partials/es/gcp_setup.md
@@ -122,7 +122,7 @@ Cuando la cuenta sea validada recibirás un email diciendo lo siguiente: "Your G
 
 ℹ️ Tienes un **crédito de $300** para usar con recursos de Google Cloud. Esto será más que suficiente para el bootcamp.
 
-- [Habilita las APIs AI Platform Training & Prediction y Compute Engine APIs](https://console.cloud.google.com/flows/enableapi?apiid=ml.googleapis.com,compute_component&_ga=2.269215094.662509797.1580849510-2071889129.1567861089&_gac=1.154971594.1580849512.CjwKCAiAyeTxBRBvEiwAuM8dnbZ6uMwizbZW44J2mBCX6ncEjwjwpgF8S8QsvhYAXLkJ8awDnIRTNRoCJ_0QAvD_BwE) (Esto puede tomar varios minutos)
+- [Habilita las APIs BigQuery y Compute Engine](https://console.cloud.google.com/flows/enableapi?apiid=bigquery,compute) (Esto puede tomar varios minutos)
 
 ### Configuración de Cloud sdk
 

--- a/_partials/gcp_setup.md
+++ b/_partials/gcp_setup.md
@@ -120,7 +120,7 @@ Once the verification goes through, you should receive an email stating that "Yo
 
 ℹ️ You have a **$300 credit** to use for Google Cloud resources, which will be more than enough for the bootcamp.
 
-- [Enable the AI Platform Training & Prediction and Compute Engine APIs](https://console.cloud.google.com/flows/enableapi?apiid=ml.googleapis.com,compute_component&_ga=2.269215094.662509797.1580849510-2071889129.1567861089&_gac=1.154971594.1580849512.CjwKCAiAyeTxBRBvEiwAuM8dnbZ6uMwizbZW44J2mBCX6ncEjwjwpgF8S8QsvhYAXLkJ8awDnIRTNRoCJ_0QAvD_BwE) (This step may take a few minutes)
+- [Enable the BigQuery and Compute Engine APIs](https://console.cloud.google.com/flows/enableapi?apiid=bigquery,compute) (This step may take a few minutes)
 
 ### Configure Cloud sdk
 

--- a/macOS.es.md
+++ b/macOS.es.md
@@ -966,7 +966,7 @@ Cuando la cuenta sea validada recibirás un email diciendo lo siguiente: "Your G
 
 ℹ️ Tienes un **crédito de $300** para usar con recursos de Google Cloud. Esto será más que suficiente para el bootcamp.
 
-- [Habilita las APIs AI Platform Training & Prediction y Compute Engine APIs](https://console.cloud.google.com/flows/enableapi?apiid=ml.googleapis.com,compute_component&_ga=2.269215094.662509797.1580849510-2071889129.1567861089&_gac=1.154971594.1580849512.CjwKCAiAyeTxBRBvEiwAuM8dnbZ6uMwizbZW44J2mBCX6ncEjwjwpgF8S8QsvhYAXLkJ8awDnIRTNRoCJ_0QAvD_BwE) (Esto puede tomar varios minutos)
+- [Habilita las APIs BigQuery y Compute Engine](https://console.cloud.google.com/flows/enableapi?apiid=bigquery,compute) (Esto puede tomar varios minutos)
 
 ### Configuración de Cloud sdk
 

--- a/macOS.es.md
+++ b/macOS.es.md
@@ -46,6 +46,8 @@ Ya puedes cerrar la aplicación Zoom.
 
 ![Foto GitHub](https://github.com/lewagon/setup/blob/master/images/github_picture.png)
 
+:point_right: **[Habilita la Autenticación de Dos Factores (2FA)](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication#configuring-two-factor-authentication-using-text-messages)**. GitHub te enviará mensajes de texto con un código cuando intentes iniciar sesión. Esto es importante para la seguridad y también pronto será necesario para contribuir código en GitHub.
+
 
 ## Chips Apple Silicon
 

--- a/macOS.md
+++ b/macOS.md
@@ -46,6 +46,8 @@ Have you signed up to GitHub? If not, [do it right away](https://github.com/join
 
 ![GitHub picture](https://github.com/lewagon/setup/blob/master/images/github_picture.png)
 
+:point_right: **[Enable Two-Factor Authentication (2FA)](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication#configuring-two-factor-authentication-using-text-messages)**. GitHub will send you text messages with a code when you try to log in. This is important for security and also will soon be required in order to contribute code on GitHub.
+
 
 ## Apple Silicon Chips
 
@@ -969,7 +971,7 @@ Once the verification goes through, you should receive an email stating that "Yo
 
 ℹ️ You have a **$300 credit** to use for Google Cloud resources, which will be more than enough for the bootcamp.
 
-- [Enable the AI Platform Training & Prediction and Compute Engine APIs](https://console.cloud.google.com/flows/enableapi?apiid=ml.googleapis.com,compute_component&_ga=2.269215094.662509797.1580849510-2071889129.1567861089&_gac=1.154971594.1580849512.CjwKCAiAyeTxBRBvEiwAuM8dnbZ6uMwizbZW44J2mBCX6ncEjwjwpgF8S8QsvhYAXLkJ8awDnIRTNRoCJ_0QAvD_BwE) (This step may take a few minutes)
+- [Enable the BigQuery and Compute Engine APIs](https://console.cloud.google.com/flows/enableapi?apiid=bigquery,compute) (This step may take a few minutes)
 
 ### Configure Cloud sdk
 


### PR DESCRIPTION
- Adding BigQuery fixes https://github.com/lewagon/data-challenges/issues/3309
- Compute link no longer worked
- AI Platform is deprecated (and no longer used since MLOps) and replaced by Vertex AI