### PR TITLE
Troubleshooting pyenv not found

### DIFF
--- a/LINUX.es.md
+++ b/LINUX.es.md
@@ -46,6 +46,8 @@ Ya puedes cerrar la aplicación Zoom.
 
 ![Foto GitHub](https://github.com/lewagon/setup/blob/master/images/github_picture.png)
 
+:point_right: **[Habilita la Autenticación de Dos Factores (2FA)](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication#configuring-two-factor-authentication-using-text-messages)**. GitHub te enviará mensajes de texto con un código cuando intentes iniciar sesión. Esto es importante para la seguridad y también pronto será necesario para contribuir código en GitHub.
+
 
 ## Visual Studio Code
 

--- a/LINUX.md
+++ b/LINUX.md
@@ -46,6 +46,8 @@ Have you signed up to GitHub? If not, [do it right away](https://github.com/join
 
 ![GitHub picture](https://github.com/lewagon/setup/blob/master/images/github_picture.png)
 
+:point_right: **[Enable Two-Factor Authentication (2FA)](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication#configuring-two-factor-authentication-using-text-messages)**. GitHub will send you text messages with a code when you try to log in. This is important for security and also will soon be required in order to contribute code on GitHub.
+
 
 ## Visual Studio Code
 
@@ -533,6 +535,27 @@ pyenv install 3.10.6
 ```
 
 This command might take a while, this is perfectly normal. Don't hesitate to help other students seated next to you!
+
+<details>
+  <summary>🛠 Troubleshooting `pyenv` not found</summary>
+
+If you encounter an error `Command 'pyenv' not found`: execute the following line:
+
+```bash
+source ~/.zprofile
+```
+
+Then try to install Python again:
+
+```bash
+pyenv install 3.10.6
+```
+
+If `pyenv` is still not found, contact a teacher.
+
+</details>
+<br>
+
 
 OK once this command is complete, we are going to tell the system to use this version of Python **by default**. This is done with:
 

--- a/VM.es.md
+++ b/VM.es.md
@@ -57,6 +57,8 @@ Lo recomendamos como navegador predeterminado porque es el más compatible con l
 
 ![Foto GitHub](https://github.com/lewagon/setup/blob/master/images/github_picture.png)
 
+:point_right: **[Habilita la Autenticación de Dos Factores (2FA)](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication#configuring-two-factor-authentication-using-text-messages)**. GitHub te enviará mensajes de texto con un código cuando intentes iniciar sesión. Esto es importante para la seguridad y también pronto será necesario para contribuir código en GitHub.
+
 
 
 

--- a/VM.md
+++ b/VM.md
@@ -57,6 +57,8 @@ Have you signed up to GitHub? If not, [do it right away](https://github.com/join
 
 ![GitHub picture](https://github.com/lewagon/setup/blob/master/images/github_picture.png)
 
+:point_right: **[Enable Two-Factor Authentication (2FA)](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication#configuring-two-factor-authentication-using-text-messages)**. GitHub will send you text messages with a code when you try to log in. This is important for security and also will soon be required in order to contribute code on GitHub.
+
 
 ## SSH key
 
@@ -894,6 +896,27 @@ pyenv install 3.10.6
 ```
 
 This command might take a while, this is perfectly normal. Don't hesitate to help other students seated next to you!
+
+<details>
+  <summary>🛠 Troubleshooting `pyenv` not found</summary>
+
+If you encounter an error `Command 'pyenv' not found`: execute the following line:
+
+```bash
+source ~/.zprofile
+```
+
+Then try to install Python again:
+
+```bash
+pyenv install 3.10.6
+```
+
+If `pyenv` is still not found, contact a teacher.
+
+</details>
+<br>
+
 
 OK once this command is complete, we are going to tell the system to use this version of Python **by default**. This is done with:
 

--- a/WINDOWS.es.md
+++ b/WINDOWS.es.md
@@ -46,6 +46,8 @@ Ya puedes cerrar la aplicación Zoom.
 
 ![Foto GitHub](https://github.com/lewagon/setup/blob/master/images/github_picture.png)
 
+:point_right: **[Habilita la Autenticación de Dos Factores (2FA)](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication#configuring-two-factor-authentication-using-text-messages)**. GitHub te enviará mensajes de texto con un código cuando intentes iniciar sesión. Esto es importante para la seguridad y también pronto será necesario para contribuir código en GitHub.
+
 
 ## La versión de Windows
 

--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -46,6 +46,8 @@ Have you signed up to GitHub? If not, [do it right away](https://github.com/join
 
 ![GitHub picture](https://github.com/lewagon/setup/blob/master/images/github_picture.png)
 
+:point_right: **[Enable Two-Factor Authentication (2FA)](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication#configuring-two-factor-authentication-using-text-messages)**. GitHub will send you text messages with a code when you try to log in. This is important for security and also will soon be required in order to contribute code on GitHub.
+
 
 ## Windows version
 
@@ -1084,6 +1086,27 @@ pyenv install 3.10.6
 ```
 
 This command might take a while, this is perfectly normal. Don't hesitate to help other students seated next to you!
+
+<details>
+  <summary>🛠 Troubleshooting `pyenv` not found</summary>
+
+If you encounter an error `Command 'pyenv' not found`: execute the following line:
+
+```bash
+source ~/.zprofile
+```
+
+Then try to install Python again:
+
+```bash
+pyenv install 3.10.6
+```
+
+If `pyenv` is still not found, contact a teacher.
+
+</details>
+<br>
+
 
 OK once this command is complete, we are going to tell the system to use this version of Python **by default**. This is done with:
 

--- a/_partials/osx_python.md
+++ b/_partials/osx_python.md
@@ -55,7 +55,27 @@ pyenv install <PYTHON_VERSION>
 This command might take a while, this is perfectly normal. Don't hesitate to help other students seated next to you!
 
 <details>
-  <summary>🛠 Troubleshooting</summary>
+  <summary>🛠 Troubleshooting `pyenv` not found</summary>
+
+If you encounter an error `Command 'pyenv' not found`: execute the following line:
+
+```bash
+source ~/.zprofile
+```
+
+Then try to install Python again:
+
+```bash
+pyenv install <PYTHON_VERSION>
+```
+
+If `pyenv` is still not found, contact a teacher.
+
+</details>
+
+
+<details>
+  <summary>🛠 Troubleshooting `zlib`</summary>
 
 If you encounter an error installing Python with `pyenv` about `zlib`:
 

--- a/_partials/ubuntu_python.md
+++ b/_partials/ubuntu_python.md
@@ -28,6 +28,27 @@ pyenv install <PYTHON_VERSION>
 
 This command might take a while, this is perfectly normal. Don't hesitate to help other students seated next to you!
 
+<details>
+  <summary>🛠 Troubleshooting `pyenv` not found</summary>
+
+If you encounter an error `Command 'pyenv' not found`: execute the following line:
+
+```bash
+source ~/.zprofile
+```
+
+Then try to install Python again:
+
+```bash
+pyenv install <PYTHON_VERSION>
+```
+
+If `pyenv` is still not found, contact a teacher.
+
+</details>
+<br>
+
+
 OK once this command is complete, we are going to tell the system to use this version of Python **by default**. This is done with:
 
 ```bash

--- a/macOS.es.md
+++ b/macOS.es.md
@@ -46,6 +46,8 @@ Ya puedes cerrar la aplicación Zoom.
 
 ![Foto GitHub](https://github.com/lewagon/setup/blob/master/images/github_picture.png)
 
+:point_right: **[Habilita la Autenticación de Dos Factores (2FA)](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication#configuring-two-factor-authentication-using-text-messages)**. GitHub te enviará mensajes de texto con un código cuando intentes iniciar sesión. Esto es importante para la seguridad y también pronto será necesario para contribuir código en GitHub.
+
 
 ## Chips Apple Silicon
 

--- a/macOS.md
+++ b/macOS.md
@@ -46,6 +46,8 @@ Have you signed up to GitHub? If not, [do it right away](https://github.com/join
 
 ![GitHub picture](https://github.com/lewagon/setup/blob/master/images/github_picture.png)
 
+:point_right: **[Enable Two-Factor Authentication (2FA)](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication#configuring-two-factor-authentication-using-text-messages)**. GitHub will send you text messages with a code when you try to log in. This is important for security and also will soon be required in order to contribute code on GitHub.
+
 
 ## Apple Silicon Chips
 
@@ -594,7 +596,27 @@ pyenv install 3.10.6
 This command might take a while, this is perfectly normal. Don't hesitate to help other students seated next to you!
 
 <details>
-  <summary>🛠 Troubleshooting</summary>
+  <summary>🛠 Troubleshooting `pyenv` not found</summary>
+
+If you encounter an error `Command 'pyenv' not found`: execute the following line:
+
+```bash
+source ~/.zprofile
+```
+
+Then try to install Python again:
+
+```bash
+pyenv install 3.10.6
+```
+
+If `pyenv` is still not found, contact a teacher.
+
+</details>
+
+
+<details>
+  <summary>🛠 Troubleshooting `zlib`</summary>
 
 If you encounter an error installing Python with `pyenv` about `zlib`:
 


### PR DESCRIPTION
Added this troubleshooting step, because during the setup it regularly occurs that pyenv is not found. Often this can be resolved by manually sourcing `.zprofile`. Reason is that some time ago pyenv was moved from `.zshrc` to `.zprofile`. `.zprofile` only gets loaded at startup, while `.zshrc` is loaded in any new terminal window, or after `exec zsh`.

Alternative would be a full restart of the computer.