### PR TITLE
Windows/Linux - Install no cuda stuff, cpu only for tf and torch

### DIFF
--- a/LINUX.es.md
+++ b/LINUX.es.md
@@ -46,6 +46,8 @@ Ya puedes cerrar la aplicación Zoom.
 
 ![Foto GitHub](https://github.com/lewagon/setup/blob/master/images/github_picture.png)
 
+:point_right: **[Habilita la Autenticación de Dos Factores (2FA)](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication#configuring-two-factor-authentication-using-text-messages)**. GitHub te enviará mensajes de texto con un código cuando intentes iniciar sesión. Esto es importante para la seguridad y también pronto será necesario para contribuir código en GitHub.
+
 
 ## Visual Studio Code
 

--- a/LINUX.md
+++ b/LINUX.md
@@ -46,6 +46,8 @@ Have you signed up to GitHub? If not, [do it right away](https://github.com/join
 
 ![GitHub picture](https://github.com/lewagon/setup/blob/master/images/github_picture.png)
 
+:point_right: **[Enable Two-Factor Authentication (2FA)](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication#configuring-two-factor-authentication-using-text-messages)**. GitHub will send you text messages with a code when you try to log in. This is important for security and also will soon be required in order to contribute code on GitHub.
+
 
 ## Visual Studio Code
 

--- a/VM.es.md
+++ b/VM.es.md
@@ -57,6 +57,8 @@ Lo recomendamos como navegador predeterminado porque es el más compatible con l
 
 ![Foto GitHub](https://github.com/lewagon/setup/blob/master/images/github_picture.png)
 
+:point_right: **[Habilita la Autenticación de Dos Factores (2FA)](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication#configuring-two-factor-authentication-using-text-messages)**. GitHub te enviará mensajes de texto con un código cuando intentes iniciar sesión. Esto es importante para la seguridad y también pronto será necesario para contribuir código en GitHub.
+
 
 
 

--- a/VM.md
+++ b/VM.md
@@ -57,6 +57,8 @@ Have you signed up to GitHub? If not, [do it right away](https://github.com/join
 
 ![GitHub picture](https://github.com/lewagon/setup/blob/master/images/github_picture.png)
 
+:point_right: **[Enable Two-Factor Authentication (2FA)](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication#configuring-two-factor-authentication-using-text-messages)**. GitHub will send you text messages with a code when you try to log in. This is important for security and also will soon be required in order to contribute code on GitHub.
+
 
 ## SSH key
 

--- a/WINDOWS.es.md
+++ b/WINDOWS.es.md
@@ -46,6 +46,8 @@ Ya puedes cerrar la aplicación Zoom.
 
 ![Foto GitHub](https://github.com/lewagon/setup/blob/master/images/github_picture.png)
 
+:point_right: **[Habilita la Autenticación de Dos Factores (2FA)](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication#configuring-two-factor-authentication-using-text-messages)**. GitHub te enviará mensajes de texto con un código cuando intentes iniciar sesión. Esto es importante para la seguridad y también pronto será necesario para contribuir código en GitHub.
+
 
 ## La versión de Windows
 

--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -46,6 +46,8 @@ Have you signed up to GitHub? If not, [do it right away](https://github.com/join
 
 ![GitHub picture](https://github.com/lewagon/setup/blob/master/images/github_picture.png)
 
+:point_right: **[Enable Two-Factor Authentication (2FA)](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication#configuring-two-factor-authentication-using-text-messages)**. GitHub will send you text messages with a code when you try to log in. This is important for security and also will soon be required in order to contribute code on GitHub.
+
 
 ## Windows version
 

--- a/macOS.es.md
+++ b/macOS.es.md
@@ -46,6 +46,8 @@ Ya puedes cerrar la aplicación Zoom.
 
 ![Foto GitHub](https://github.com/lewagon/setup/blob/master/images/github_picture.png)
 
+:point_right: **[Habilita la Autenticación de Dos Factores (2FA)](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication#configuring-two-factor-authentication-using-text-messages)**. GitHub te enviará mensajes de texto con un código cuando intentes iniciar sesión. Esto es importante para la seguridad y también pronto será necesario para contribuir código en GitHub.
+
 
 ## Chips Apple Silicon
 

--- a/macOS.md
+++ b/macOS.md
@@ -46,6 +46,8 @@ Have you signed up to GitHub? If not, [do it right away](https://github.com/join
 
 ![GitHub picture](https://github.com/lewagon/setup/blob/master/images/github_picture.png)
 
+:point_right: **[Enable Two-Factor Authentication (2FA)](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication#configuring-two-factor-authentication-using-text-messages)**. GitHub will send you text messages with a code when you try to log in. This is important for security and also will soon be required in order to contribute code on GitHub.
+
 
 ## Apple Silicon Chips
 

--- a/specs/releases/linux.txt
+++ b/specs/releases/linux.txt
@@ -127,18 +127,18 @@ nltk==3.7
 notebook==6.4.12
 notebook_shim==0.2.0
 numpy==1.23.4
-nvidia-cublas-cu12==12.1.3.1
-nvidia-cuda-cupti-cu12==12.1.105
-nvidia-cuda-nvrtc-cu12==12.1.105
-nvidia-cuda-runtime-cu12==12.1.105
-nvidia-cudnn-cu12==8.9.2.26
-nvidia-cufft-cu12==11.0.2.54
-nvidia-curand-cu12==10.3.2.106
-nvidia-cusolver-cu12==11.4.5.107
-nvidia-cusparse-cu12==12.1.0.106
-nvidia-nccl-cu12==2.18.1
-nvidia-nvjitlink-cu12==12.2.140
-nvidia-nvtx-cu12==12.1.105
+# nvidia-cublas-cu12==12.1.3.1
+# nvidia-cuda-cupti-cu12==12.1.105
+# nvidia-cuda-nvrtc-cu12==12.1.105
+# nvidia-cuda-runtime-cu12==12.1.105
+# nvidia-cudnn-cu12==8.9.2.26
+# nvidia-cufft-cu12==11.0.2.54
+# nvidia-curand-cu12==10.3.2.106
+# nvidia-cusolver-cu12==11.4.5.107
+# nvidia-cusparse-cu12==12.1.0.106
+# nvidia-nccl-cu12==2.18.1
+# nvidia-nvjitlink-cu12==12.2.140
+# nvidia-nvtx-cu12==12.1.105
 oauthlib==3.2.2
 opt-einsum==3.3.0
 packaging==21.3
@@ -223,7 +223,7 @@ tenacity==8.1.0
 tensorboard==2.10.1
 tensorboard-data-server==0.6.1
 tensorboard-plugin-wit==1.8.1
-tensorflow==2.10.0
+tensorflow-cpu==2.10.0
 tensorflow-datasets==4.6.0
 tensorflow-estimator==2.10.0
 tensorflow-io-gcs-filesystem==0.27.0
@@ -239,7 +239,8 @@ toml==0.10.2
 tomli==2.0.1
 tomlkit==0.11.5
 toolz==0.12.0
-torch==2.1.0
+# torch 2.1.0 cpu only on the next line
+https://download.pytorch.org/whl/cpu-cxx11-abi/torch-2.1.0%2Bcpu.cxx11.abi-cp310-cp310-linux_x86_64.whl
 tornado==6.2
 TPOT==0.11.7
 tqdm==4.64.1


### PR DESCRIPTION
Setup on Windows and Ubuntu takes ages because we install gpu enabled versions of tensorflow and torch, while very few students have a gpu. Especially knowing that torch is only there for the Transformers day.

- Use tensorflow-cpu
- Specify wheel location for torch so it downloads a cpu versions
- Remove all unnecessary nvidia-cu... packages

This reduces the virtualenv size with 4 Gb!
```bash
9.4G	./lewagon
5.4G	./lwlight
```

Fixes https://github.com/lewagon/data-setup/issues/285