### PR TITLE
Pip check instructs to ask a TA for help

### DIFF
--- a/checks/pip_check.sh
+++ b/checks/pip_check.sh
@@ -41,11 +41,11 @@ for r in ${REQUIRED[@]}; do
   fi
 done
 if (( ${#missing[@]} )); then
-  sentence='Try to `pip install '
+  sentence='❌ Some packages are missing: '
   sentence+=$missing
-  sentence+='` again.'
-  echo '❌ Some packages are missing:'
   echo $sentence
+  echo '👉 Ask a TA for help to check your python setup.'
+  echo '   Note to TAs: First thing to do: redo the Python packages step of the instructions.'
   exit 1
 else
   echo '✅ Everything is fine, continue the setup instructions.'


### PR DESCRIPTION
Previously we instructed to `pip install` the
missing packages. This leads to a very different
setup than we aim for, because no version numbers
are provided.

Changed this to:
- list the packages
- instruct the students to call in a TA
- note to TA to redo the Python packages step (usually the root cause is that Apple users skipped that step)