### PR TITLE
Remove jupyerlab-spellchecker from the specs

### DIFF
--- a/specs/releases/apple_intel.txt
+++ b/specs/releases/apple_intel.txt
@@ -86,7 +86,6 @@ jupyterlab-code-formatter==3.0.2
 jupyterlab-execute-time==3.2.0
 jupyterlab-pygments==0.3.0
 jupyterlab-server==2.27.3
-jupyterlab-spellchecker==0.8.4
 jupyterlab-widgets==3.0.13
 jupyterlab==4.3.5
 kagglehub==0.3.9

--- a/specs/releases/apple_silicon.txt
+++ b/specs/releases/apple_silicon.txt
@@ -86,7 +86,6 @@ jupyterlab-code-formatter==3.0.2
 jupyterlab-execute-time==3.2.0
 jupyterlab-pygments==0.3.0
 jupyterlab-server==2.27.3
-jupyterlab-spellchecker==0.8.4
 jupyterlab-widgets==3.0.13
 jupyterlab==4.3.5
 kagglehub==0.3.9

--- a/specs/releases/linux.txt
+++ b/specs/releases/linux.txt
@@ -86,7 +86,6 @@ jupyterlab-code-formatter==3.0.2
 jupyterlab-execute-time==3.2.0
 jupyterlab-pygments==0.3.0
 jupyterlab-server==2.27.3
-jupyterlab-spellchecker==0.8.4
 jupyterlab-widgets==3.0.13
 jupyterlab==4.3.5
 kagglehub==0.3.9


### PR DESCRIPTION
The extension has a bug: it spellchecks code cells, which is very annoying. It doesn't seem to be maintained, so we're removing it.