### PR TITLE
Align Windows 11 and 10 WSL installation

### DIFF
--- a/WINDOWS.es.md
+++ b/WINDOWS.es.md
@@ -62,65 +62,54 @@ Para chequear la versión de tu Windows:
 - Escribe  `winver`
 - Presiona `Enter`
 
-:heavy_check_mark: Si las primeras palabras de esta ventana son **Windows 10 o Windows 11**, entonces todo está bien y puedes continuar trabajando en la configuración :+1:
+:heavy_check_mark: Si las primeras palabras de esta ventana son **Windows 11**, entonces todo está bien y puedes continuar trabajando en la configuración :+1:
 
-:x: Si no es el caso, no puedes continuar. Primero debes actualizar tu versión a Windows 10 :point_down:
+:heavy_check_mark: Si las primeras palabras de esta ventana son **Windows 10**, verifica el **número de la versión**:
 
-<details>
-  <summary>Actualizar a Windows 10</summary>
+- :heavy_check_mark: Si dice al menos `2004`, entonces todo está bien :+1:
 
-  - Descarga Windows 10 desde [Microsoft](https://www.microsoft.com/software-download/windows10ISO)
-  - Instálalo. Debería tomar como una hora pero realmente depende de tu computadora.
-  - Cuando termine la instalación, ejecuta los comandos de aquí arriba :point_up: para chequear que tengas **Windows 10**.
-</details>
+- :x: Si es inferior a `2004`, debes actualizar tu versión.
 
-:information_source: [La actualización de Windows 11 está en curso en este momento](https://www.microsoft.com/en-us/windows/get-windows-11). Esto significa que puede que esté o que aún no esté disponible para tu computadora.
+- <details>
+  <summary>Cómo instalar las últimas actualizaciones?</summary>
 
-:warning: **Si tienes Windows 10 instalado, no necesitas actualizarlo a Windows 11 para hacer esta configuración**.
-
-### Últimas actualizaciones
-
-Una vez que estés seguro de que estés usando Windows 10 o 11, instala las siguientes actualizaciones.
-
-Abre Windows Update:
-- Presiona `Windows` + `R`
-- Escribe `ms-settings:windowsupdate`
-- Presiona `Enter`
-- Haz clic en `Check updates`
-
-:heavy_check_mark: Si tienes una marca verde y el siguiente mensaje "You're up to date", entonces todo está bien :+1:
-
-:warning: Si obtienes una exclamación roja y el siguiente mensaje "Update available", por favor instala las actualizaciones y repite el proceso hasta que diga que todo está actualizado :loop:
-
-:x: Si obtienes un mensaje de error diciendo que Windows no puede aplicar las actualizaciones, por favor **contacta a un profesor**.
-
-<details>
-  <summary>Activa Windows Update Service para resolver las Actualizaciones</summary>
-
-  Algunos antivirus y programas deshabilitan las actualizaciones que necesitamos y luego se muestra un error. ¡Solucionemos esto!
+  Abre Windows Update:
   - Presiona `Windows` + `R`
-  - Escribe `services.msc`
+  - Escribe `ms-settings:windowsupdate`
   - Presiona `Enter`
-  - Haz doble clic en `Windows Update Service`
-  - Coloca su `Startup` en `Automatic`
-  - Haz clic en `Start`
-  - Haz clic en `Ok`
-  ¡Ahora intenta instalar las actualizaciones nuevamente!
-</details>
+  - Haz clic en `Check updates`
 
-### Requisito mínimo para la versión
+  :heavy_check_mark: Si tienes una marca verde y el siguiente mensaje "You're up to date", entonces todo está bien :+1:
 
-Algunas de las herramientas que necesitamos han salido con la versión `1903` **o superior** de Windows 10, así que necesitamos asegurarnos de que al menos tengamos esa.
+  :warning: Si obtienes una exclamación roja y el siguiente mensaje "Update available", por favor instala las actualizaciones y repite el proceso hasta que diga que todo está actualizado :loop:
 
-- Presiona `Windows` + `R`
-- Escribe  `winver`
-- Presiona `Enter`
+  :x: Si obtienes un mensaje de error diciendo que Windows no puede aplicar las actualizaciones, por favor **contacta a un profesor**.
 
-Verifica el **número de la versión**:
+  <details>
+    <summary>Activa Windows Update Service para resolver las Actualizaciones</summary>
 
-:heavy_check_mark: Si dice al menos `1903`, entonces todo está bien :+1:
+    Algunos antivirus y programas deshabilitan las actualizaciones que necesitamos y luego se muestra un error. ¡Solucionemos esto!
+    - Presiona `Windows` + `R`
+    - Escribe `services.msc`
+    - Presiona `Enter`
+    - Haz doble clic en `Windows Update Service`
+    - Coloca su `Startup` en `Automatic`
+    - Haz clic en `Start`
+    - Haz clic en `Ok`
+    ¡Ahora intenta instalar las actualizaciones nuevamente!
+  </details>
 
-:x: Si es inferior a `1903`, por favor **contacta a un profesor**.
+  Verifica el número de la versión:
+
+  - Presiona `Windows` + `R`
+  - Escribe  `winver`
+  - Presiona `Enter`
+
+  :heavy_check_mark: Si dice al menos `2004`, entonces todo está bien :+1:
+
+  :x: Si es inferior a `2004`, por favor **contacta a un profesor**.
+
+  </details>
 
 
 ## Virtualización
@@ -166,21 +155,17 @@ Normalmente ya es el caso en muchas computadoras. Verifiquemos:
 
 WSL es el ambiente de entorno que estamos usando para usar Ubuntu. Puedes aprender más sobre WSL [aquí](https://docs.microsoft.com/en-us/windows/wsl/faq).
 
-:information_source: Las instrucciones que verás a continuación dependen de la versión de Windows que tengas. Por favor ejecuta solamente las instrucciones que correspondan a tu versión :point_down:
+Instalaremos WSL 2 y Ubuntu con un comando a través de la Windows Command Prompt.
 
-### Windows 11
-
-Si usas Windows 11, instalaremos WSL 2 y Ubuntu con un comando a través de la terminal de Windows.
-
-:warning: en esta instrucción, utiliza el atajo `Ctrl` + `Shift` + `Enter` para usar la **terminal de Windows** con privilegios de administrador en lugar de simplemente hacer clic en `Ok` o presionar `Enter`.
+:warning: en esta instrucción, utiliza el atajo `Ctrl` + `Shift` + `Enter` para usar la **Windows Command Prompt** con privilegios de administrador en lugar de simplemente hacer clic en `Ok` o presionar `Enter`.
 
 - Presiona `Windows` + `R`
-- Escribe `wt`
+- Escribe `cmd`
 - Presiona **`Ctrl` + `Shift` + `Enter`**
 
 :warning: tal vez tengas que aceptar la confirmación UAC sobre el cambio en los privilegios.
 
-Un ventana de terminal azul aparecerá:
+Un ventana de terminal aparecerá:
 - Copia el siguiente comando (`Ctrl` + `C`)
 - Pégalo en la ventana de la terminal (`Ctrl` + `V` o haciendo clic derecho en la ventana)
 - Ejecútalo presionado `Enter`
@@ -193,11 +178,10 @@ wsl --install
 
 :x: Si obtienes un mensaje de error (o si ves algún texto en rojo en la ventana), por favor **contacta a un profesor**
 
-### Windows 10
+<details>
+<summary>Solución de problemas para Windows 10 (solo si es necesario, consulta con un profesor)</summary>
 
-#### Instalación de WSL 1
-
-Si tienes Windows 10, primero instalaremos WSL 1 por medio de la Terminal de PowerShell.
+#### Para Windows 10 < 2004: instala primero WSL 1
 
 :warning: en esta instrucción, utiliza el atajo `Ctrl` + `Shift` + `Enter` para usar **Windows PowerShell** con privilegios de administrador en lugar de hacer clic en `Ok` o presionar `Enter`.
 
@@ -228,7 +212,7 @@ dism.exe /online /enable-feature /featurename:VirtualMachinePlatform /all /nores
 
 :x: Si obtienes un mensaje de error (o si ves algún texto en rojo en la ventada), por favor **contacta a un profesor**
 
-#### Actualización a WSL 2
+#### Para Windows 10 con WSL 1: Actualización a WSL 2
 
 Si tienes Windows 10, actualizaremos WSL a la versión 2.
 
@@ -246,7 +230,7 @@ Cuando se reinicie tu computadora, descarga el instalador de WSL2.
 
 :x: Si obtienes el siguiente error "This update only applies to machines with the Windows Subsystem for Linux", **haz clic derecho** en el programa y selecciona `uninstall`; esta vez deberías poder instalarlo sin problemas.
 
-#### Coloca WSL 2 como el Subsistema Windows por defecto para Linux
+#### Para Windows 10 con WSL 1: Coloca WSL 2 como el Subsistema Windows por defecto para Linux
 
 Si tienes Windows 10, pondremos la versión predeterminada de WSL en 2.
 
@@ -279,18 +263,20 @@ wsl --set-default-version 2
   :information_source: Si tienes Windows 10 **Home edition**, la feature Hyper-V no está disponible para su sistema operativo. No es un bloqueo y puedes continuar con las siguientes instrucciones aquí abajo :ok_hand:
 </details>
 
+</details>
+
 
 ## Ubuntu
 
 ### Instalación
 
-:information_source: Las instrucciones que verás a continuación dependen de la versión de Windows que tengas. Por favor solo sigue las instrucciones que correspondan a tu versión de Windows :point_down:
+Después de reiniciar tu computadora, deberías ver una ventana de terminal diciendo WSL está retomando el proceso de instalación de Ubuntu. Cuando termine, iniciará Ubuntu.
 
-#### Windows 11
+<details>
+<summary>Solución de problemas para Windows 10 (solo si es necesario, consulta con un profesor)</summary>
 
-Si estás utilizando Windows 11, después de reiniciar tu computadora, deberías ver una ventana de terminal diciendo WSL está retomando el proceso de instalación de Ubuntu. Cuando termine, iniciará Ubuntu.
-
-#### Windows 10
+Si la instalación de Ubuntu no se reanudó, primero intenta nuevamente: abre Powershell o el Símbolo del sistema y ejecuta `wsl --install` otra vez.
+</details>
 
 Si tienes Windows 10, instala la terminal de Windows por medio de la Microsoft Store:
 
@@ -316,6 +302,8 @@ Si tienes Windows 10, instala la terminal de Windows por medio de la Microsoft S
 
 Cuando termine la instalación, el botón `Get` se transformará en un botón `Open`: Haz clic en él.
 
+</details>
+
 ### Primer uso
 
 La primera vez que lo abras, te pedirán que:
@@ -328,8 +316,6 @@ La primera vez que lo abras, te pedirán que:
 - Confírmalo
 
 :warning: Cuando escribas tu contraseña no verás nada en la pantalla. **Esto es normal**. Es una herramienta de seguridad para ocultar tanto el contenido de tu contraseña como su longitud. Simplemente escribe tu contraseña y presiona `Enter` al terminar.
-
-Ahora puedes cerrar la ventana de Ubuntu ya que está instalado en tu computadora.
 
 ### Chequea la versión WSL de Ubuntu
 
@@ -359,7 +345,6 @@ wsl -l -v
   :heavy_check_mark: Deberías obtener el siguiente mensaje en algunos segundos: `The conversion is complete`. Esto significa que la conversión ha sido completada.
 
   :x: Si no funciona, tendremos que asegurarnos de que los archivos de Ubuntu no estén comprimidos.
-</details>
 
 <details>
   <summary>Chequea si los archivos no están comprimidos</summary>
@@ -378,7 +363,23 @@ wsl -l -v
   :x: Si la conversión aún no funciona, por favor **contacta a un profesor**.
 </details>
 
-### Compruebe la locale
+Ya puedes cerrar la ventana de la terminal.
+
+</details>
+
+### Comprueba tu nombre de usuario
+
+Escribe esto en la terminal de Ubuntu:
+
+```bash
+whoami
+```
+
+Debería devolver el nombre de usuario que elegiste anteriormente.
+
+:x: Si dice `root`, **contacta a un profesor** antes de continuar.
+
+### Comprueba la configuración regional (locale)
 
 La "locale" es un mecanismo que permite adaptar los programas a su idioma y país.
 
@@ -407,8 +408,6 @@ sudo apt-get update
 sudo apt-get install language-pack-en language-pack-en-base manpages
 ```
 </details>
-
-Ya puedes cerrar la ventana de la terminal.
 
 
 ## Chrome - tu navegador
@@ -470,8 +469,10 @@ code .
 
 Si estás utilizando Windows 11, la terminal de Windows ya está instalada y puedes ir a la siguiente sección :point_down:
 
+Si tienes Windows 10, instala la terminal de Windows. Verás que es una terminal moderna.
 
-Si tienes Windows 10, instala la terminal de Windows. Verás que es una terminal moderna:
+<details>
+<summary>**Windows 10**: Instalar Windows Terminal</summary>
 
 - Haz clic en `Start`
 - Escribe `Microsoft Store`
@@ -495,6 +496,8 @@ Si tienes Windows 10, instala la terminal de Windows. Verás que es una terminal
 </details>
 
 Cuando termine la instalación, el botón `Install` se transformará en un botón `Launch`: haz clic en él.
+
+</details>
 
 ### Ubuntu como terminal predeterminada
 

--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -62,65 +62,54 @@ To check your Windows version:
 - Type  `winver`
 - Press `Enter`
 
-:heavy_check_mark: If the first words of this window are **Windows 10 or Windows 11** you're good to go :+1:
+:heavy_check_mark: If the first words of this window are **Windows 11** you're good to go :+1:
 
-:x: If not, you cannot proceed with this setup. You have to upgrade to Windows 10 first :point_down:
+If the first words of this window are **Windows 10**, check the **Version number**:
 
-<details>
-  <summary>Upgrade to Windows 10</summary>
+- :heavy_check_mark: If it says at least `2004`, you are good to go :+1:
 
-  - Download Windows 10 from [Microsoft](https://www.microsoft.com/software-download/windows10ISO)
-  - Install it. It should take roughly an hour, but this depends on your computer.
-  - When the installation is over, execute the commands above :point_up: to check that you now have **Windows 10**.
-</details>
+- :x: If it is below `2004`, you need to run an update.
 
-:information_source: [Windows 11 upgrade is rolling out now](https://www.microsoft.com/en-us/windows/get-windows-11), which means it may or may not be available for your computer just yet.
+- <details>
+  <summary>How to install updates?</summary>
 
-:warning: **If you have Windows 10 installed, you don't need to upgrade to Windows 11 to proceed with this setup**.
-
-### Latest updates
-
-Once you're sure that you're using Windows 10 or 11, you need to install all the latest updates.
-
-Open Windows Update:
-- Press `Windows` + `R`
-- Type  `ms-settings:windowsupdate`
-- Press `Enter`
-- Click on `Check updates`
-
-:heavy_check_mark: If you see a green check mark and the message "You're up to date", you're good to go :+1:
-
-:warning: If you have a red exclamation mark and the message "Update available", please install them and repeat the process until it says that you are up to date :loop:
-
-:x: If you have an error message about Windows not being able to apply updates, please **contact a teacher**.
-
-<details>
-  <summary>Activate Windows Update Service to fix Updates</summary>
-
-  Some antiviruses and pieces of software deactivate the Update service we need, resulting in the error you see. Let's fix that!
+  Open Windows Update:
   - Press `Windows` + `R`
-  - Type  `services.msc`
+  - Type  `ms-settings:windowsupdate`
   - Press `Enter`
-  - Double Click `Windows Update Service`
-  - Set its `Startup` to `Automatic`
-  - Click on `Start`
-  - Click on `Ok`
-  Then let's try updates again!
-</details>
+  - Click on `Check updates`
 
-### Minimum version
+  :heavy_check_mark: If you see a green check mark and the message "You're up to date", you're good to go :+1:
 
-Some of the tools we need to install have been release with the `1903` version **or above** of Windows 10 so we need to make sure you have at least this one.
+  :warning: If you have a red exclamation mark and the message "Update available", please install them and repeat the process until it says that you are up to date :loop:
 
-- Press `Windows` + `R`
-- Type  `winver`
-- Press `Enter`
+  :x: If you have an error message about Windows not being able to apply updates, please **contact a teacher**.
 
-Check the **Version number**:
+  <details>
+    <summary>Activate Windows Update Service to fix Updates</summary>
 
-:heavy_check_mark: If it says at least `1903`, you are good to go :+1:
+    Some antiviruses and pieces of software deactivate the Update service we need, resulting in the error you see. Let's fix that!
+    - Press `Windows` + `R`
+    - Type  `services.msc`
+    - Press `Enter`
+    - Double Click `Windows Update Service`
+    - Set its `Startup` to `Automatic`
+    - Click on `Start`
+    - Click on `Ok`
+    Then let's try updates again!
+  </details>
 
-:x: If it is below `1903`, please **contact a teacher**.
+  Check the version number again:
+
+  - Press `Windows` + `R`
+  - Type  `winver`
+  - Press `Enter`
+
+  :heavy_check_mark: If it says at least `2004`, you are good to go :+1:
+
+  :x: If it is below `2004`, **contact a TA**.
+
+  </details>
 
 
 ## Virtualization
@@ -166,21 +155,17 @@ For many computers, this is already the case. Let's check:
 
 WSL is the development environment we are using to run Ubuntu. You can learn more about WSL [here](https://docs.microsoft.com/en-us/windows/wsl/faq).
 
-:information_source: The following instructions depend on your version of Windows. Please execute only the instructions corresponding to your version :point_down:
+We will install WSL 2 and Ubuntu in one command through the Windows Command Prompt.
 
-### Windows 11
-
-If you are running Windows 11, we will install WSL 2 and Ubuntu in one command through the Windows Terminal.
-
-:warning: In the following instruction, please be aware of the `Ctrl` + `Shift` + `Enter` key stroke to execute **Windows Terminal** with administrator privileges instead of just clicking on `Ok`or pressing `Enter`.
+:warning: In the following instruction, please be aware of the `Ctrl` + `Shift` + `Enter` key stroke to execute **Windows Command Prompt** with administrator privileges instead of just clicking on `Ok`or pressing `Enter`.
 
 - Press `Windows` + `R`
-- Type  `wt`
+- Type  `cmd`
 - Press **`Ctrl` + `Shift` + `Enter`**
 
 :warning: You may have to accept the UAC confirmation about the privilege elevation.
 
-A blue terminal window will appear:
+A black terminal window will appear:
 - Copy the following command (`Ctrl` + `C`)
 - Paste it into the terminal window (`Ctrl` + `V` or by right-clicking in the window)
 - Run it by pressing `Enter`
@@ -191,13 +176,13 @@ wsl --install
 
 :heavy_check_mark: If the command ran without any error, please restart your computer and continue below :+1:
 
-:x: If you encounter an error message (or if you see some text in red in the window), please **contact a teacher**
+:x: If you encounter an error message (or if you see some text in red in the window), please **contact a teacher**.
 
-### Windows 10
+<details>
+<summary>Troubleshooting for Windows 10 (only if needed, check with a TA)
+</summary>
 
-#### Install WSL 1
-
-If you are running Windows 10, we will first install WSL 1 through the PowerShell Terminal.
+#### For Windows 10 < 2004: install WSL 1 first
 
 :warning: In the following instruction, please be aware of the `Ctrl` + `Shift` + `Enter` key stroke to execute **Windows PowerShell** with administrator privileges instead of just clicking on `Ok`or pressing `Enter`.
 
@@ -228,7 +213,7 @@ dism.exe /online /enable-feature /featurename:VirtualMachinePlatform /all /nores
 
 :x: If you encounter an error message (or if you see some text in red in the window), please **contact a teacher**
 
-#### Upgrade to WSL 2
+#### For Windows 10 users running WSL 1: Upgrade to WSL 2
 
 If you are running Windows 10, we will then upgrade WSL to version 2.
 
@@ -246,7 +231,7 @@ Once your computer has restarted, we need to download the WSL2 installer.
 
 :x: If you encounter the error "This update only applies to machines with the Windows Subsystem for Linux", **right click** on the program and select `uninstall`; you shall be able to install it normally this time.
 
-#### Make WSL 2 the default Windows Subsystem for Linux
+#### For Windows 10 users running WSL 1: Make WSL 2 the default Windows Subsystem for Linux
 
 If you are running Windows 10, we will set WSL default version to 2.
 
@@ -279,18 +264,20 @@ wsl --set-default-version 2
   :information_source: If you are running Windows 10 **Home edition**, Hyper-V feature is not available for your operating system. It's non-blocking and you can still continue to follow the instructions below :ok_hand:
 </details>
 
+</details>
+
 
 ## Ubuntu
 
 ### Installation
 
-:information_source: The following instructions depend on your version of Windows. Please execute only the instructions corresponding to your version :point_down:
+After restarting you computer, you should see a terminal window saying WSL is resuming the Ubuntu installation process. When it's done, Ubuntu will be launched.
 
-#### Windows 11
+<details>
+<summary>Troubleshooting for Windows 10 (only if needed, check with a TA)
+</summary>
 
-If you are running Windows 11, after restarting you computer, you should see a terminal window saying WSL is resuming the Ubuntu installation process. When it's done, Ubuntu will be launched.
-
-#### Windows 10
+If the Ubuntu installation did not resume, first try it again: launch Powershell or the Command Prompt again and run `wsl --install` again.
 
 If you are running Windows 10, let's install Ubuntu throught the Microsoft Store:
 
@@ -316,6 +303,8 @@ If you are running Windows 10, let's install Ubuntu throught the Microsoft Store
 
 Once the installation is finished, the `Get` button becomes a `Open` button: click on it.
 
+</details>
+
 ### First launch
 
 At first launch, you will be asked some information:
@@ -329,7 +318,6 @@ At first launch, you will be asked some information:
 
 :warning: When you type your password, nothing will show up on the screen, **that's normal**. This is a security feature to mask not only your password as a whole but also its length. Just type your password and when you're done, press `Enter`.
 
-You can close the Ubuntu window now that it is installed on your computer.
 
 ### Check the WSL version of Ubuntu
 
@@ -359,7 +347,6 @@ wsl -l -v
   :heavy_check_mark: After a few seconds, you should get the following message: `The conversion is complete`.
 
   :x: If it does not work, we need to be sure that Ubuntu files are not compressed.
-</details>
 
 <details>
   <summary>Check for Uncompressed Files</summary>
@@ -377,6 +364,22 @@ wsl -l -v
 
   :x: If the conversion still does not work, please **contact a teacher**.
 </details>
+
+You can close this terminal now.
+
+</details>
+
+### Check your username
+
+Type this in the Ubuntu terminal:
+
+```bash
+whoami
+```
+
+It should return the username you chose before.
+
+:x: It if says `root`, **contact a TA** before continuing!
 
 ### Check the locale
 
@@ -407,8 +410,6 @@ sudo apt-get update
 sudo apt-get install language-pack-en language-pack-en-base manpages
 ```
 </details>
-
-You can now close this terminal window.
 
 
 ## Chrome - your browser
@@ -470,7 +471,10 @@ code .
 
 If you are running Windows 11, the Windows Terminal is already installed and you can proceed to the next section :point_down:
 
-If you are running Windows 10, let's install Windows Terminal, a real modern terminal:
+If you are running Windows 10, let's install Windows Terminal, a real modern terminal.
+
+<details>
+<summary><strong>Windows 10</strong>: Install Windows Terminal</summary>
 
 - Click on `Start`
 - Type  `Microsoft Store`
@@ -495,6 +499,8 @@ If you are running Windows 10, let's install Windows Terminal, a real modern ter
 
 Once the installation is finished, the `Install` button becomes a `Launch` button: click on it.
 
+</details>
+
 ### Ubuntu as the default terminal
 
 Let's make Ubuntu the default terminal of your Windows Terminal application.
@@ -511,7 +517,7 @@ It should open the terminal settings:
 
 You may see an orange circle rather than a penguin as the logo for Ubuntu.
 
-We have circle in red the part you will change:
+We have circled in red the part you need to change:
 
 ![Windows Terminal JSON settings file](https://github.com/lewagon/setup/blob/master/images/windows_terminal_settings_json.png)
 
@@ -525,7 +531,7 @@ First, let's ask Ubuntu to start directly inside your Ubuntu Home Directory inst
 
 :warning: Do not forget the comma at the end of the line!
 
-Then, let's disable warning for copy-pasting commands between Windows and Ubuntu:
+Then, let's disable warnings for copy-pasting commands between Windows and Ubuntu:
 - Locate the line `"defaultProfile": "{2c4de342-...}"`
 - Add the following line after it:
 


### PR DESCRIPTION
Starting from Windows 10 2004 (May 2020 Update), WSL 2 is the default
version of WSL. The instructions for installing WSL 2 are now the same
for both Windows 10 and Windows 11.

Adapted the instructions as such, to have a common installation process.

This will:
- make the setup easier for remaining Windows 10 users,
- reduce the  number of cases where Windows 11 users started following
  the Windows 10 instructions by mistake,
- make it easier to maintain the instructions in the future,
- make it easy to remove the Windows 10 instructions later.

For this we now run `wsl --install` in the Windows Command Prompt (cmd)
instead of Windows Terminal (wt, for Windows 11) or PowerShell (for
Windows 10).

For troubleshooting reasons, the instructions for Windows 10 < 2004 are
kept in details, just in case.

Adapted EN, FR, ES, PT in Web. EN and ES in  DS.

This mirrors https://github.com/lewagon/setup/pull/483 in the Web setup.