### PR TITLE
Remove 32-bit C++ Redistributable

### DIFF
--- a/WINDOWS.es.md
+++ b/WINDOWS.es.md
@@ -1310,11 +1310,6 @@ Algunos paquetes Python requieren de un compilador para funcionar correctamente,
 [For x64 systems](https://aka.ms/vs/16/release/vc_redist.x64.exe)
 
 
-[For x86 systems](https://aka.ms/vs/16/release/vc_redist.x86.exe)
-
-Si no sabes qué programa estás usando, por favor pídele ayuda a un profesor.
-
-
 ## Docker 🐋
 
 Docker es una plataforma abierta para desarrollo, entrega y operación de aplicaciones.

--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -1368,11 +1368,6 @@ Some Python packages require a compiler to function properly. Let's install one:
 [For x64 systems](https://aka.ms/vs/16/release/vc_redist.x64.exe)
 
 
-[For x86 systems](https://aka.ms/vs/16/release/vc_redist.x86.exe)
-
-If you're unsure about which system you're using please ask a teacher.
-
-
 ## Docker 🐋
 
 Docker is an open platform for developing, shipping, and running applications.

--- a/_partials/es/win_vs_redistributable.md
+++ b/_partials/es/win_vs_redistributable.md
@@ -3,8 +3,3 @@
 Algunos paquetes Python requieren de un compilador para funcionar correctamente, así que vamos a instalar uno:
 
 [For x64 systems](https://aka.ms/vs/16/release/vc_redist.x64.exe)
-
-
-[For x86 systems](https://aka.ms/vs/16/release/vc_redist.x86.exe)
-
-Si no sabes qué programa estás usando, por favor pídele ayuda a un profesor.

--- a/_partials/win_vs_redistributable.md
+++ b/_partials/win_vs_redistributable.md
@@ -3,8 +3,3 @@
 Some Python packages require a compiler to function properly. Let's install one:
 
 [For x64 systems](https://aka.ms/vs/16/release/vc_redist.x64.exe)
-
-
-[For x86 systems](https://aka.ms/vs/16/release/vc_redist.x86.exe)
-
-If you're unsure about which system you're using please ask a teacher.


### PR DESCRIPTION
Currently we tell students to choose one or the other.

- This is confusing some students
- It is very unlikely to see a 32-bit system at this point
- A 32-bit Windows would only have 4 Gb of RAM, which doesn't meat our minimum requirement of 8 Gb of RAM