### PR TITLE
Bump keras to 3.11.3 (latest)

### DIFF
--- a/specs/releases/apple_intel.txt
+++ b/specs/releases/apple_intel.txt
@@ -86,7 +86,7 @@ jupyterlab==4.3.5
 kagglehub==0.3.9
 keras-hub==0.19.0
 keras-nlp==0.19.0
-keras==3.8.0
+keras==3.11.3
 kiwisolver==1.4.8
 lazy-loader==0.4
 libclang==18.1.1

--- a/specs/releases/apple_silicon.txt
+++ b/specs/releases/apple_silicon.txt
@@ -86,7 +86,7 @@ jupyterlab==4.3.5
 kagglehub==0.3.9
 keras-hub==0.19.0
 keras-nlp==0.19.0
-keras==3.8.0
+keras==3.11.3
 kiwisolver==1.4.8
 lazy-loader==0.4
 libclang==18.1.1

--- a/specs/releases/linux.txt
+++ b/specs/releases/linux.txt
@@ -86,7 +86,7 @@ jupyterlab==4.3.5
 kagglehub==0.3.9
 keras-hub==0.19.0
 keras-nlp==0.19.0
-keras==3.8.0
+keras==3.11.3
 kiwisolver==1.4.8
 lazy-loader==0.4
 libclang==18.1.1


### PR DESCRIPTION
This new Keras version fixes:
- "Import keras.something could not be resolved" from Pylance, including its squiggly lines underneath the import.
- Not showing autocomplete and documentation in VS Code.